### PR TITLE
feat: sync frontend with backend data

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { EconomyPanel } from './components/EconomyPanel';
 import { MiniGamePanel } from './components/MiniGamePanel';
 import { EventFeed } from './components/EventFeed';
 import { TopBar } from './components/TopBar';
+import { StatsPanel } from './components/StatsPanel';
 import styles from './App.module.css';
 
 export const App = () => (
@@ -15,6 +16,7 @@ export const App = () => (
       </div>
       <aside className={styles.sidebar}>
         <EconomyPanel />
+        <StatsPanel />
         <EventFeed />
       </aside>
     </main>

--- a/frontend/src/components/EconomyPanel.module.css
+++ b/frontend/src/components/EconomyPanel.module.css
@@ -19,6 +19,12 @@
   color: rgba(245, 248, 255, 0.65);
 }
 
+.connection {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: rgba(245, 248, 255, 0.75);
+}
+
 .metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -54,6 +60,11 @@
   cursor: pointer;
 }
 
+.actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .tradeForm {
   display: grid;
   grid-template-columns: 1fr 1fr auto;
@@ -72,4 +83,10 @@
 .tradeForm button {
   background: rgba(123, 92, 255, 0.2);
   color: var(--accent);
+}
+
+.refreshButton {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(245, 248, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }

--- a/frontend/src/components/GameObjectCard.tsx
+++ b/frontend/src/components/GameObjectCard.tsx
@@ -1,4 +1,7 @@
+import { useMutation } from '@tanstack/react-query';
+import { useAccount } from 'wagmi';
 import { ActiveObject, useGameStore } from '../state/gameStore';
+import { destroyGameObject, type BalancesResponse, type DestroyPayload } from '../services/gameApi';
 import styles from './GameObjectCard.module.css';
 
 const rewardLabel = (object: ActiveObject): string => {
@@ -13,10 +16,41 @@ type Props = {
 };
 
 export const GameObjectCard = ({ object }: Props) => {
+  const { address } = useAccount();
   const destroyObject = useGameStore((state) => state.destroyObject);
+  const syncBackendBalances = useGameStore((state) => state.syncBackendBalances);
+  const addEvent = useGameStore((state) => state.addEvent);
+
+  const { mutate } = useMutation<BalancesResponse, Error, DestroyPayload>({
+    mutationFn: destroyGameObject,
+    onSuccess: (balances, variables) => {
+      syncBackendBalances({
+        hashBalance: balances.hashBalance,
+        unmintedHash: balances.unmintedHash,
+      });
+      addEvent(`Backend recorded destroy for ${variables.objectId}. Balances synced.`);
+    },
+    onError: (error) => {
+      addEvent(`Failed to sync destroy with backend: ${error.message}`);
+    },
+  });
 
   return (
-    <button className={styles.card} onClick={() => destroyObject(object.id)} type="button">
+    <button
+      className={styles.card}
+      onClick={() => {
+        destroyObject(object.id);
+        if (address) {
+          mutate({
+            wallet: address,
+            objectId: object.id,
+            reward: object.reward.type === 'unminted_hash' ? object.reward.value : undefined,
+            objectName: object.type,
+          });
+        }
+      }}
+      type="button"
+    >
       <span className={styles.label}>{object.type}</span>
       <span className={styles.reward}>{rewardLabel(object)}</span>
       <span className={styles.meta}>Health: {object.health}</span>

--- a/frontend/src/components/StatsPanel.module.css
+++ b/frontend/src/components/StatsPanel.module.css
@@ -1,0 +1,114 @@
+.panel {
+  background: var(--surface-alt);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(123, 92, 255, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(245, 248, 255, 0.65);
+}
+
+.status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 248, 255, 0.55);
+}
+
+.syncing {
+  color: var(--accent);
+}
+
+.error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #ff9b9b;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.meta img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 0.6rem;
+}
+
+.placeholder {
+  width: 40px;
+  height: 40px;
+  border-radius: 0.6rem;
+  display: grid;
+  place-items: center;
+  background: rgba(123, 92, 255, 0.2);
+  color: var(--accent);
+  font-size: 1.25rem;
+}
+
+.meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.meta strong {
+  font-size: 0.95rem;
+}
+
+.meta span {
+  font-size: 0.75rem;
+  color: rgba(245, 248, 255, 0.55);
+}
+
+.count {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.empty {
+  text-align: center;
+  font-size: 0.85rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.15);
+}

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query';
+import clsx from 'clsx';
+import { fetchGameStats } from '../services/gameApi';
+import styles from './StatsPanel.module.css';
+
+export const StatsPanel = () => {
+  const {
+    data: stats,
+    isFetching,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['game-stats'],
+    queryFn: fetchGameStats,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+
+  return (
+    <section className={styles.panel}>
+      <header className={styles.header}>
+        <h2>Object Telemetry</h2>
+        <p>Live destroy counts synced from the backend.</p>
+        <span className={clsx(styles.status, { [styles.syncing]: isFetching })}>
+          {isFetching ? 'Syncing…' : 'Up to date'}
+        </span>
+      </header>
+      {isError ? (
+        <p className={styles.error}>
+          {(error instanceof Error ? error.message : 'Unable to load stats')}
+        </p>
+      ) : (
+        <ul className={styles.list}>
+          {(stats ?? []).map((entry) => (
+            <li key={entry.objectId}>
+              <div className={styles.meta}>
+                {entry.image ? (
+                  <img src={entry.image} alt="" />
+                ) : (
+                  <span className={styles.placeholder} aria-hidden="true">
+                    ◎
+                  </span>
+                )}
+                <div>
+                  <strong>{entry.name || entry.objectId}</strong>
+                  <span>{entry.objectId}</span>
+                </div>
+              </div>
+              <span className={styles.count}>{entry.destroyed}</span>
+            </li>
+          ))}
+          {!stats?.length && !isFetching && (
+            <li className={styles.empty}>No telemetry recorded yet.</li>
+          )}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -1,0 +1,77 @@
+import { appEnv } from '../config/env';
+
+type StatsEntry = {
+  objectId: string;
+  name: string;
+  image: string;
+  destroyed: number;
+};
+
+type BalancesResponse = {
+  hashBalance: number | string;
+  unmintedHash: number | string;
+};
+
+type DestroyPayload = {
+  wallet: string;
+  objectId: string;
+  reward?: number;
+  objectName?: string;
+  objectImage?: string;
+};
+
+const trimmedBaseUrl = appEnv.backendUrl ? appEnv.backendUrl.replace(/\/$/, '') : '';
+const apiBase = `${trimmedBaseUrl}/api/game`;
+
+const createUrl = (path: string) => `${apiBase}${path}`;
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    let message = 'Unexpected error communicating with backend';
+    try {
+      const data = await response.json();
+      if (typeof data?.error === 'string') {
+        message = data.error;
+      }
+    } catch (error) {
+      // ignore json parse errors
+    }
+    throw new Error(message);
+  }
+  return response.json() as Promise<T>;
+};
+
+export const fetchGameStats = async (): Promise<StatsEntry[]> => {
+  const response = await fetch(createUrl('/stats'), {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+  return handleResponse<StatsEntry[]>(response);
+};
+
+export const fetchBalances = async (wallet: string): Promise<BalancesResponse> => {
+  const url = new URL(createUrl('/balances'), window.location.origin);
+  url.searchParams.set('wallet', wallet);
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+  return handleResponse<BalancesResponse>(response);
+};
+
+export const destroyGameObject = async (payload: DestroyPayload): Promise<BalancesResponse> => {
+  const response = await fetch(createUrl('/destroy'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<BalancesResponse>(response);
+};
+
+export type { StatsEntry, BalancesResponse, DestroyPayload };

--- a/frontend/src/state/gameStore.ts
+++ b/frontend/src/state/gameStore.ts
@@ -92,6 +92,8 @@ type GameState = {
   resolveMiniGame: () => void;
   settleDailyMint: () => void;
   tradeInForHash: (amount: number) => void;
+  syncBackendBalances: (payload: { hashBalance: number | string; unmintedHash: number | string }) => void;
+  addEvent: (message: string) => void;
 };
 
 const pushEvent = (events: EventEntry[], message: string): EventEntry[] => {
@@ -205,6 +207,30 @@ export const useGameStore = create<GameState>()(
           events,
         };
       }, false, 'tradeInForHash');
+    },
+    syncBackendBalances: ({ hashBalance, unmintedHash }) => {
+      const parse = (value: number | string) => {
+        const numeric = typeof value === 'string' ? Number(value) : value;
+        if (!Number.isFinite(numeric)) {
+          return 0;
+        }
+        return Number(numeric.toFixed(10));
+      };
+
+      set((state) => ({
+        ...state,
+        balances: {
+          ...state.balances,
+          hash: parse(hashBalance),
+          unminted: parse(unmintedHash),
+        },
+      }), false, 'syncBackendBalances');
+    },
+    addEvent: (message) => {
+      set((state) => ({
+        ...state,
+        events: pushEvent(state.events, message),
+      }), false, 'addEvent');
     },
   }))
 );

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",
+    "noEmit": true,
     "types": ["vite/client"]
   },
   "include": ["src"],


### PR DESCRIPTION
## What changed and why
- wire the game board and economy panels to the live backend by introducing a shared API client and syncing wallet balances after destroys
- add a telemetry panel that streams `/api/game/stats` so operators can confirm objects are being recorded by the service
- surface backend sync events in the local event feed and harden the TypeScript config to avoid stray JS build output

## Any schema or API changes?
- None; the frontend now consumes the existing `/api/game` endpoints.

## How to test locally
- pnpm install
- pnpm -C frontend build

## Screenshots for UI
- Unable to capture within the container because installing frontend dependencies requires registry access that is blocked in this environment.


------
https://chatgpt.com/codex/tasks/task_e_68dc651e8728832e89860be9887a7d5b