### PR TITLE
feat: animate floating game objects

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { EconomyPanel } from './components/EconomyPanel';
 import { MiniGamePanel } from './components/MiniGamePanel';
 import { EventFeed } from './components/EventFeed';
 import { TopBar } from './components/TopBar';
+import { StatsPanel } from './components/StatsPanel';
 import styles from './App.module.css';
 
 export const App = () => (
@@ -15,6 +16,7 @@ export const App = () => (
       </div>
       <aside className={styles.sidebar}>
         <EconomyPanel />
+        <StatsPanel />
         <EventFeed />
       </aside>
     </main>

--- a/frontend/src/components/EconomyPanel.module.css
+++ b/frontend/src/components/EconomyPanel.module.css
@@ -19,6 +19,12 @@
   color: rgba(245, 248, 255, 0.65);
 }
 
+.connection {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: rgba(245, 248, 255, 0.75);
+}
+
 .metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -54,6 +60,11 @@
   cursor: pointer;
 }
 
+.actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .tradeForm {
   display: grid;
   grid-template-columns: 1fr 1fr auto;
@@ -72,4 +83,10 @@
 .tradeForm button {
   background: rgba(123, 92, 255, 0.2);
   color: var(--accent);
+}
+
+.refreshButton {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(245, 248, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }

--- a/frontend/src/components/GameBoard.module.css
+++ b/frontend/src/components/GameBoard.module.css
@@ -1,6 +1,21 @@
 .board {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
+  position: relative;
   width: 100%;
+  min-height: 540px;
+  border-radius: 1.75rem;
+  background: radial-gradient(circle at 25% 20%, rgba(77, 60, 181, 0.45), transparent 45%),
+    radial-gradient(circle at 70% 15%, rgba(224, 96, 255, 0.32), transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(64, 198, 255, 0.26), rgba(8, 10, 28, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  box-shadow: 0 32px 60px rgba(9, 5, 32, 0.55);
+}
+
+.board::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 40%, rgba(255, 255, 255, 0.04) 70%);
+  mix-blend-mode: screen;
 }

--- a/frontend/src/components/GameBoard.module.css
+++ b/frontend/src/components/GameBoard.module.css
@@ -1,21 +1,11 @@
 .board {
   position: relative;
   width: 100%;
-  min-height: 540px;
-  border-radius: 1.75rem;
-  background: radial-gradient(circle at 25% 20%, rgba(77, 60, 181, 0.45), transparent 45%),
-    radial-gradient(circle at 70% 15%, rgba(224, 96, 255, 0.32), transparent 50%),
-    radial-gradient(circle at 50% 80%, rgba(64, 198, 255, 0.26), rgba(8, 10, 28, 0.92));
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 32rem;
+  padding: 3rem;
+  border-radius: 1.5rem;
   overflow: hidden;
-  box-shadow: 0 32px 60px rgba(9, 5, 32, 0.55);
-}
-
-.board::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 40%, rgba(255, 255, 255, 0.04) 70%);
-  mix-blend-mode: screen;
+  background: radial-gradient(circle at 50% 30%, rgba(75, 58, 180, 0.35), rgba(10, 8, 28, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 60px rgba(0, 0, 0, 0.45);
 }

--- a/frontend/src/components/GameObjectCard.module.css
+++ b/frontend/src/components/GameObjectCard.module.css
@@ -1,79 +1,85 @@
 .card {
   position: absolute;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
   border: none;
-  background: none;
+  background: transparent;
   padding: 0;
   cursor: pointer;
-  transform: translate(-50%, -50%);
-  animation-name: float;
-  animation-duration: var(--float-duration, 8s);
-  animation-delay: var(--float-delay, 0s);
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
-  animation-direction: alternate;
-  filter: drop-shadow(0 18px 28px rgba(20, 10, 45, 0.45));
-  transition: transform 0.3s ease;
-  will-change: transform;
+  transform-origin: center;
+  animation: float var(--float-duration) ease-in-out infinite;
+  animation-delay: var(--float-delay);
 }
 
-.card:hover {
-  transform: translate(calc(-50% + 2px), calc(-50% - 4px));
+.card::after {
+  content: '';
+  position: absolute;
+  inset: -12%;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(123, 92, 255, 0.25), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
 }
 
 .card:focus-visible {
-  outline: 2px solid rgba(123, 92, 255, 0.8);
+  outline: 3px solid rgba(255, 255, 255, 0.6);
   outline-offset: 6px;
+}
+
+.card:hover::after,
+.card:focus-visible::after {
+  opacity: 1;
 }
 
 .sprite {
   width: 100%;
   height: 100%;
   object-fit: contain;
+  filter: drop-shadow(0 10px 25px rgba(20, 12, 55, 0.35));
+  animation: drift var(--float-duration) ease-in-out infinite;
+  animation-delay: var(--sprite-delay);
   pointer-events: none;
 }
 
 .caption {
   position: absolute;
-  top: 100%;
+  bottom: -3.5rem;
   left: 50%;
-  transform: translate(-50%, 0.75rem);
-  background: rgba(7, 6, 20, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 0.75rem;
-  padding: 0.5rem 0.85rem;
+  transform: translateX(-50%);
+  min-width: 12rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.8rem;
+  background: rgba(10, 8, 28, 0.85);
   color: #f5f8ff;
-  font-size: 0.75rem;
-  line-height: 1.2;
   text-align: center;
+  box-shadow: 0 12px 24px rgba(12, 8, 32, 0.45);
   opacity: 0;
-  pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease;
-  white-space: nowrap;
-  box-shadow: 0 10px 22px rgba(9, 5, 18, 0.55);
+  pointer-events: none;
 }
 
 .card:hover .caption,
 .card:focus-visible .caption {
   opacity: 1;
-  transform: translate(-50%, 0.25rem);
+  transform: translate(-50%, -4px);
 }
 
 .name {
   display: block;
   font-weight: 600;
-  font-size: 0.8rem;
+  font-size: 0.95rem;
 }
 
 .reward {
   display: block;
-  font-size: 0.72rem;
-  color: rgba(245, 248, 255, 0.76);
+  font-size: 0.8rem;
+  color: rgba(245, 248, 255, 0.75);
+  margin-top: 0.2rem;
 }
 
-.accessibleLabel {
+.visuallyHidden {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -81,19 +87,25 @@
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
   border: 0;
 }
 
 @keyframes float {
-  from {
-    transform: translate(-50%, -50%);
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
   }
+  50% {
+    transform: translate(calc(-50% + var(--drift-x)), calc(-50% + var(--drift-y))) scale(1.04);
+  }
+}
 
-  to {
-    transform: translate(
-        calc(-50% + var(--drift-x, 0px)),
-        calc(-50% + var(--drift-y, 0px))
-      );
+@keyframes drift {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
   }
 }

--- a/frontend/src/components/GameObjectCard.module.css
+++ b/frontend/src/components/GameObjectCard.module.css
@@ -1,34 +1,99 @@
 .card {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: var(--surface);
-  padding: 1rem;
-  border-radius: 0.8rem;
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  padding: 0;
   cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-  text-transform: capitalize;
+  transform: translate(-50%, -50%);
+  animation-name: float;
+  animation-duration: var(--float-duration, 8s);
+  animation-delay: var(--float-delay, 0s);
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  filter: drop-shadow(0 18px 28px rgba(20, 10, 45, 0.45));
+  transition: transform 0.3s ease;
+  will-change: transform;
 }
 
 .card:hover {
-  border-color: var(--accent);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 18px rgba(123, 92, 255, 0.25);
+  transform: translate(calc(-50% + 2px), calc(-50% - 4px));
 }
 
-.label {
+.card:focus-visible {
+  outline: 2px solid rgba(123, 92, 255, 0.8);
+  outline-offset: 6px;
+}
+
+.sprite {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.caption {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 0.75rem);
+  background: rgba(7, 6, 20, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.85rem;
+  color: #f5f8ff;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  white-space: nowrap;
+  box-shadow: 0 10px 22px rgba(9, 5, 18, 0.55);
+}
+
+.card:hover .caption,
+.card:focus-visible .caption {
+  opacity: 1;
+  transform: translate(-50%, 0.25rem);
+}
+
+.name {
+  display: block;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.8rem;
 }
 
 .reward {
-  font-size: 0.85rem;
-  color: rgba(245, 248, 255, 0.7);
+  display: block;
+  font-size: 0.72rem;
+  color: rgba(245, 248, 255, 0.76);
 }
 
-.meta {
-  font-size: 0.75rem;
-  color: rgba(245, 248, 255, 0.52);
+.accessibleLabel {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes float {
+  from {
+    transform: translate(-50%, -50%);
+  }
+
+  to {
+    transform: translate(
+        calc(-50% + var(--drift-x, 0px)),
+        calc(-50% + var(--drift-y, 0px))
+      );
+  }
 }

--- a/frontend/src/components/GameObjectCard.tsx
+++ b/frontend/src/components/GameObjectCard.tsx
@@ -24,6 +24,7 @@ export const GameObjectCard = ({ object }: Props) => {
       height: `${object.sprite.size}px`,
       '--float-duration': `${object.motion.floatDuration}s`,
       '--float-delay': `${object.motion.floatDelay}s`,
+      '--sprite-delay': `${-object.motion.floatDelay}s`,
       '--drift-x': `${object.motion.driftX}px`,
       '--drift-y': `${object.motion.driftY}px`,
     };
@@ -38,17 +39,19 @@ export const GameObjectCard = ({ object }: Props) => {
     object.sprite.size,
   ]);
 
+  const label = `${object.sprite.name} — ${rewardLabel(object)}`;
+
   return (
     <button
       className={styles.card}
       onClick={() => destroyObject(object.id)}
       type="button"
       style={floatingStyle}
-      aria-label={`${object.sprite.name} — ${rewardLabel(object)}`}
+      aria-label={label}
     >
-      <span className={styles.accessibleLabel}>{`${object.sprite.name} ${rewardLabel(object)}`}</span>
+      <span className={styles.visuallyHidden}>{label}</span>
       <img src={object.sprite.image} alt="" className={styles.sprite} />
-      <span className={styles.caption}>
+      <span className={styles.caption} aria-hidden="true">
         <span className={styles.name}>{object.sprite.name}</span>
         <span className={styles.reward}>{rewardLabel(object)}</span>
       </span>

--- a/frontend/src/components/GameObjectCard.tsx
+++ b/frontend/src/components/GameObjectCard.tsx
@@ -1,4 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { useAccount } from 'wagmi';
+import { type CSSProperties, useMemo } from 'react';
 import { ActiveObject, useGameStore } from '../state/gameStore';
+import { destroyGameObject, type BalancesResponse, type DestroyPayload } from '../services/gameApi';
 import styles from './GameObjectCard.module.css';
 
 const rewardLabel = (object: ActiveObject): string => {
@@ -13,13 +17,71 @@ type Props = {
 };
 
 export const GameObjectCard = ({ object }: Props) => {
+  const { address } = useAccount();
   const destroyObject = useGameStore((state) => state.destroyObject);
+  const syncBackendBalances = useGameStore((state) => state.syncBackendBalances);
+  const addEvent = useGameStore((state) => state.addEvent);
+
+  const { mutate } = useMutation<BalancesResponse, Error, DestroyPayload>({
+    mutationFn: destroyGameObject,
+    onSuccess: (balances, variables) => {
+      syncBackendBalances({
+        hashBalance: balances.hashBalance,
+        unmintedHash: balances.unmintedHash,
+      });
+      addEvent(`Backend recorded destroy for ${variables.objectId}. Balances synced.`);
+    },
+    onError: (error) => {
+      addEvent(`Failed to sync destroy with backend: ${error.message}`);
+    },
+  });
+
+  const floatingStyle = useMemo(() => {
+    const style: CSSProperties & Record<string, string> = {
+      top: `${object.motion.y}%`,
+      left: `${object.motion.x}%`,
+      width: `${object.sprite.size}px`,
+      height: `${object.sprite.size}px`,
+      '--float-duration': `${object.motion.floatDuration}s`,
+      '--float-delay': `${object.motion.floatDelay}s`,
+      '--drift-x': `${object.motion.driftX}px`,
+      '--drift-y': `${object.motion.driftY}px`,
+    };
+    return style;
+  }, [
+    object.motion.driftX,
+    object.motion.driftY,
+    object.motion.floatDelay,
+    object.motion.floatDuration,
+    object.motion.x,
+    object.motion.y,
+    object.sprite.size,
+  ]);
 
   return (
-    <button className={styles.card} onClick={() => destroyObject(object.id)} type="button">
-      <span className={styles.label}>{object.type}</span>
-      <span className={styles.reward}>{rewardLabel(object)}</span>
-      <span className={styles.meta}>Health: {object.health}</span>
+    <button
+      className={styles.card}
+      onClick={() => {
+        destroyObject(object.id);
+        if (address) {
+          mutate({
+            wallet: address,
+            objectId: object.id,
+            reward: object.reward.type === 'unminted_hash' ? object.reward.value : undefined,
+            objectName: object.type,
+          });
+        }
+      }}
+      type="button"
+      style={floatingStyle}
+      aria-label={`${object.sprite.name} — ${rewardLabel(object)}`}
+    >
+      <span className={styles.accessibleLabel}>{`${object.sprite.name} ${rewardLabel(object)}`}</span>
+      <img src={object.sprite.image} alt="" className={styles.sprite} />
+      <span className={styles.caption}>
+        <span className={styles.name}>{object.sprite.name}</span>
+        <span className={styles.reward}>{rewardLabel(object)}</span>
+      </span>
     </button>
   );
 };

--- a/frontend/src/components/GameObjectCard.tsx
+++ b/frontend/src/components/GameObjectCard.tsx
@@ -68,7 +68,8 @@ export const GameObjectCard = ({ object }: Props) => {
             wallet: address,
             objectId: object.id,
             reward: object.reward.type === 'unminted_hash' ? object.reward.value : undefined,
-            objectName: object.type,
+            objectName: object.sprite.name,
+            objectImage: object.sprite.image,
           });
         }
       }}

--- a/frontend/src/components/StatsPanel.module.css
+++ b/frontend/src/components/StatsPanel.module.css
@@ -1,0 +1,114 @@
+.panel {
+  background: var(--surface-alt);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(123, 92, 255, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(245, 248, 255, 0.65);
+}
+
+.status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 248, 255, 0.55);
+}
+
+.syncing {
+  color: var(--accent);
+}
+
+.error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #ff9b9b;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.meta img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 0.6rem;
+}
+
+.placeholder {
+  width: 40px;
+  height: 40px;
+  border-radius: 0.6rem;
+  display: grid;
+  place-items: center;
+  background: rgba(123, 92, 255, 0.2);
+  color: var(--accent);
+  font-size: 1.25rem;
+}
+
+.meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.meta strong {
+  font-size: 0.95rem;
+}
+
+.meta span {
+  font-size: 0.75rem;
+  color: rgba(245, 248, 255, 0.55);
+}
+
+.count {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.empty {
+  text-align: center;
+  font-size: 0.85rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.15);
+}

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query';
+import clsx from 'clsx';
+import { fetchGameStats } from '../services/gameApi';
+import styles from './StatsPanel.module.css';
+
+export const StatsPanel = () => {
+  const {
+    data: stats,
+    isFetching,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['game-stats'],
+    queryFn: fetchGameStats,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+
+  return (
+    <section className={styles.panel}>
+      <header className={styles.header}>
+        <h2>Object Telemetry</h2>
+        <p>Live destroy counts synced from the backend.</p>
+        <span className={clsx(styles.status, { [styles.syncing]: isFetching })}>
+          {isFetching ? 'Syncing…' : 'Up to date'}
+        </span>
+      </header>
+      {isError ? (
+        <p className={styles.error}>
+          {(error instanceof Error ? error.message : 'Unable to load stats')}
+        </p>
+      ) : (
+        <ul className={styles.list}>
+          {(stats ?? []).map((entry) => (
+            <li key={entry.objectId}>
+              <div className={styles.meta}>
+                {entry.image ? (
+                  <img src={entry.image} alt="" />
+                ) : (
+                  <span className={styles.placeholder} aria-hidden="true">
+                    ◎
+                  </span>
+                )}
+                <div>
+                  <strong>{entry.name || entry.objectId}</strong>
+                  <span>{entry.objectId}</span>
+                </div>
+              </div>
+              <span className={styles.count}>{entry.destroyed}</span>
+            </li>
+          ))}
+          {!stats?.length && !isFetching && (
+            <li className={styles.empty}>No telemetry recorded yet.</li>
+          )}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -1,0 +1,77 @@
+import { appEnv } from '../config/env';
+
+type StatsEntry = {
+  objectId: string;
+  name: string;
+  image: string;
+  destroyed: number;
+};
+
+type BalancesResponse = {
+  hashBalance: number | string;
+  unmintedHash: number | string;
+};
+
+type DestroyPayload = {
+  wallet: string;
+  objectId: string;
+  reward?: number;
+  objectName?: string;
+  objectImage?: string;
+};
+
+const trimmedBaseUrl = appEnv.backendUrl ? appEnv.backendUrl.replace(/\/$/, '') : '';
+const apiBase = `${trimmedBaseUrl}/api/game`;
+
+const createUrl = (path: string) => `${apiBase}${path}`;
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    let message = 'Unexpected error communicating with backend';
+    try {
+      const data = await response.json();
+      if (typeof data?.error === 'string') {
+        message = data.error;
+      }
+    } catch (error) {
+      // ignore json parse errors
+    }
+    throw new Error(message);
+  }
+  return response.json() as Promise<T>;
+};
+
+export const fetchGameStats = async (): Promise<StatsEntry[]> => {
+  const response = await fetch(createUrl('/stats'), {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+  return handleResponse<StatsEntry[]>(response);
+};
+
+export const fetchBalances = async (wallet: string): Promise<BalancesResponse> => {
+  const url = new URL(createUrl('/balances'), window.location.origin);
+  url.searchParams.set('wallet', wallet);
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+  return handleResponse<BalancesResponse>(response);
+};
+
+export const destroyGameObject = async (payload: DestroyPayload): Promise<BalancesResponse> => {
+  const response = await fetch(createUrl('/destroy'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<BalancesResponse>(response);
+};
+
+export type { StatsEntry, BalancesResponse, DestroyPayload };

--- a/frontend/src/state/gameStore.ts
+++ b/frontend/src/state/gameStore.ts
@@ -34,6 +34,12 @@ export type GameObjectType =
   | 'plinko'
   | 'vault';
 
+export type SpawnDefinition = {
+  type: GameObjectType;
+  spawnChance: number;
+  reward: RewardDefinition;
+};
+
 type ObjectSprite = {
   name: string;
   image: string;
@@ -49,80 +55,37 @@ type ObjectMotion = {
   driftY: number;
 };
 
-export type SpawnDefinition = {
-  type: GameObjectType;
-  spawnChance: number;
-  reward: RewardDefinition;
-  sprite: ObjectSprite;
-};
-
 export type ActiveObject = SpawnDefinition & {
   id: string;
   health: number;
+  sprite: ObjectSprite;
   motion: ObjectMotion;
 };
 
 const spawnTable: SpawnDefinition[] = [
-  {
-    type: 'circle',
-    spawnChance: 0.13,
-    reward: { type: 'unminted_hash', value: 0.000000012 },
-    sprite: { name: 'Lumen Seed', image: objectSprite00, size: 110 },
-  },
-  {
-    type: 'triangle',
-    spawnChance: 0.1,
-    reward: { type: 'unminted_hash', value: 0.000000016 },
-    sprite: { name: 'Flux Bloom', image: objectSprite01, size: 120 },
-  },
-  {
-    type: 'hexagon',
-    spawnChance: 0.1,
-    reward: { type: 'unminted_hash', value: 0.00000002 },
-    sprite: { name: 'Spectral Prism', image: objectSprite02, size: 130 },
-  },
-  {
-    type: 'prism',
-    spawnChance: 0.08,
-    reward: { type: 'unminted_hash', value: 0.000000024 },
-    sprite: { name: 'Nebula Coil', image: objectSprite03, size: 124 },
-  },
-  {
-    type: 'cube',
-    spawnChance: 0.08,
-    reward: { type: 'unminted_hash', value: 0.000000028 },
-    sprite: { name: 'Vault Shard', image: objectSprite04, size: 120 },
-  },
-  {
-    type: 'diamond',
-    spawnChance: 0.11,
-    reward: { type: 'unminted_hash', value: 0.000000032 },
-    sprite: { name: 'Auric Spire', image: objectSprite10, size: 138 },
-  },
-  {
-    type: 'wheel',
-    spawnChance: 0.1,
-    reward: { type: 'mini_game', label: 'Wheel Spin' },
-    sprite: { name: 'Spin Catalyst', image: objectSprite11, size: 134 },
-  },
-  {
-    type: 'slot',
-    spawnChance: 0.1,
-    reward: { type: 'mini_game', label: 'Slot Rush' },
-    sprite: { name: 'Slot Matrix', image: objectSprite12, size: 126 },
-  },
-  {
-    type: 'plinko',
-    spawnChance: 0.1,
-    reward: { type: 'mini_game', label: 'Plinko Drop' },
-    sprite: { name: 'Plinko Cradle', image: objectSprite13, size: 132 },
-  },
-  {
-    type: 'vault',
-    spawnChance: 0.1,
-    reward: { type: 'unminted_hash', value: 0.00000005 },
-    sprite: { name: 'Hash Vault Core', image: objectSprite14, size: 148 },
-  },
+  { type: 'circle', spawnChance: 0.18, reward: { type: 'unminted_hash', value: 0.00000001 } },
+  { type: 'triangle', spawnChance: 0.12, reward: { type: 'unminted_hash', value: 0.000000014 } },
+  { type: 'hexagon', spawnChance: 0.1, reward: { type: 'unminted_hash', value: 0.000000018 } },
+  { type: 'prism', spawnChance: 0.08, reward: { type: 'unminted_hash', value: 0.00000002 } },
+  { type: 'cube', spawnChance: 0.07, reward: { type: 'unminted_hash', value: 0.000000024 } },
+  { type: 'diamond', spawnChance: 0.1, reward: { type: 'unminted_hash', value: 0.00000003 } },
+  { type: 'wheel', spawnChance: 0.12, reward: { type: 'mini_game', label: 'Wheel Spin' } },
+  { type: 'slot', spawnChance: 0.08, reward: { type: 'mini_game', label: 'Slot Rush' } },
+  { type: 'plinko', spawnChance: 0.08, reward: { type: 'mini_game', label: 'Plinko Drop' } },
+  { type: 'vault', spawnChance: 0.07, reward: { type: 'unminted_hash', value: 0.00000005 } },
+];
+
+const spriteAtlas: ObjectSprite[] = [
+  { name: 'Lumen Seed', image: objectSprite00, size: 108 },
+  { name: 'Flux Bloom', image: objectSprite01, size: 120 },
+  { name: 'Spectral Prism', image: objectSprite02, size: 128 },
+  { name: 'Nebula Coil', image: objectSprite03, size: 118 },
+  { name: 'Vault Shard', image: objectSprite04, size: 116 },
+  { name: 'Auric Spire', image: objectSprite10, size: 134 },
+  { name: 'Spin Catalyst', image: objectSprite11, size: 132 },
+  { name: 'Slot Matrix', image: objectSprite12, size: 126 },
+  { name: 'Plinko Cradle', image: objectSprite13, size: 130 },
+  { name: 'Hash Vault Core', image: objectSprite14, size: 144 },
 ];
 
 let nextObjectId = 1;
@@ -145,12 +108,14 @@ const createMotion = (): ObjectMotion => ({
 
 const createObject = (): ActiveObject => {
   const definition = spawnTable[spawnCursor % spawnTable.length];
+  const sprite = spriteAtlas[spawnCursor % spriteAtlas.length];
   spawnCursor += 1;
   const id = `object-${nextObjectId++}`;
   return {
     ...definition,
     id,
     health: definition.type === 'vault' ? 3 : 1,
+    sprite: { ...sprite },
     motion: createMotion(),
   };
 };
@@ -185,8 +150,6 @@ type GameState = {
   resolveMiniGame: () => void;
   settleDailyMint: () => void;
   tradeInForHash: (amount: number) => void;
-  syncBackendBalances: (payload: { hashBalance: number | string; unmintedHash: number | string }) => void;
-  addEvent: (message: string) => void;
 };
 
 const pushEvent = (events: EventEntry[], message: string): EventEntry[] => {
@@ -306,30 +269,6 @@ export const useGameStore = create<GameState>()(
           events,
         };
       }, false, 'tradeInForHash');
-    },
-    syncBackendBalances: ({ hashBalance, unmintedHash }) => {
-      const parse = (value: number | string) => {
-        const numeric = typeof value === 'string' ? Number(value) : value;
-        if (!Number.isFinite(numeric)) {
-          return 0;
-        }
-        return Number(numeric.toFixed(10));
-      };
-
-      set((state) => ({
-        ...state,
-        balances: {
-          ...state.balances,
-          hash: parse(hashBalance),
-          unminted: parse(unmintedHash),
-        },
-      }), false, 'syncBackendBalances');
-    },
-    addEvent: (message) => {
-      set((state) => ({
-        ...state,
-        events: pushEvent(state.events, message),
-      }), false, 'addEvent');
     },
   }))
 );

--- a/frontend/src/state/gameStore.ts
+++ b/frontend/src/state/gameStore.ts
@@ -1,6 +1,17 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
+const objectSprite00 = new URL('../../../images/Object 0-0.png', import.meta.url).href;
+const objectSprite01 = new URL('../../../images/Object0-1.png', import.meta.url).href;
+const objectSprite02 = new URL('../../../images/Object0-2.png', import.meta.url).href;
+const objectSprite03 = new URL('../../../images/Object0-3.png', import.meta.url).href;
+const objectSprite04 = new URL('../../../images/Object0-4.png', import.meta.url).href;
+const objectSprite10 = new URL('../../../images/Object1-0.png', import.meta.url).href;
+const objectSprite11 = new URL('../../../images/Object1-1.png', import.meta.url).href;
+const objectSprite12 = new URL('../../../images/Object1-2.png', import.meta.url).href;
+const objectSprite13 = new URL('../../../images/Object1-3.png', import.meta.url).href;
+const objectSprite14 = new URL('../../../images/Object1-4.png', import.meta.url).href;
+
 type RewardDefinition =
   | {
       type: 'unminted_hash';
@@ -23,25 +34,95 @@ export type GameObjectType =
   | 'plinko'
   | 'vault';
 
+type ObjectSprite = {
+  name: string;
+  image: string;
+  size: number;
+};
+
+type ObjectMotion = {
+  x: number;
+  y: number;
+  floatDuration: number;
+  floatDelay: number;
+  driftX: number;
+  driftY: number;
+};
+
 export type SpawnDefinition = {
   type: GameObjectType;
   spawnChance: number;
   reward: RewardDefinition;
+  sprite: ObjectSprite;
 };
 
-export type ActiveObject = SpawnDefinition & { id: string; health: number };
+export type ActiveObject = SpawnDefinition & {
+  id: string;
+  health: number;
+  motion: ObjectMotion;
+};
 
 const spawnTable: SpawnDefinition[] = [
-  { type: 'circle', spawnChance: 0.18, reward: { type: 'unminted_hash', value: 0.00000001 } },
-  { type: 'triangle', spawnChance: 0.12, reward: { type: 'unminted_hash', value: 0.000000014 } },
-  { type: 'hexagon', spawnChance: 0.1, reward: { type: 'unminted_hash', value: 0.000000018 } },
-  { type: 'prism', spawnChance: 0.08, reward: { type: 'unminted_hash', value: 0.00000002 } },
-  { type: 'cube', spawnChance: 0.07, reward: { type: 'unminted_hash', value: 0.000000024 } },
-  { type: 'diamond', spawnChance: 0.1, reward: { type: 'unminted_hash', value: 0.00000003 } },
-  { type: 'wheel', spawnChance: 0.12, reward: { type: 'mini_game', label: 'Wheel Spin' } },
-  { type: 'slot', spawnChance: 0.08, reward: { type: 'mini_game', label: 'Slot Rush' } },
-  { type: 'plinko', spawnChance: 0.08, reward: { type: 'mini_game', label: 'Plinko Drop' } },
-  { type: 'vault', spawnChance: 0.07, reward: { type: 'unminted_hash', value: 0.00000005 } },
+  {
+    type: 'circle',
+    spawnChance: 0.13,
+    reward: { type: 'unminted_hash', value: 0.000000012 },
+    sprite: { name: 'Lumen Seed', image: objectSprite00, size: 110 },
+  },
+  {
+    type: 'triangle',
+    spawnChance: 0.1,
+    reward: { type: 'unminted_hash', value: 0.000000016 },
+    sprite: { name: 'Flux Bloom', image: objectSprite01, size: 120 },
+  },
+  {
+    type: 'hexagon',
+    spawnChance: 0.1,
+    reward: { type: 'unminted_hash', value: 0.00000002 },
+    sprite: { name: 'Spectral Prism', image: objectSprite02, size: 130 },
+  },
+  {
+    type: 'prism',
+    spawnChance: 0.08,
+    reward: { type: 'unminted_hash', value: 0.000000024 },
+    sprite: { name: 'Nebula Coil', image: objectSprite03, size: 124 },
+  },
+  {
+    type: 'cube',
+    spawnChance: 0.08,
+    reward: { type: 'unminted_hash', value: 0.000000028 },
+    sprite: { name: 'Vault Shard', image: objectSprite04, size: 120 },
+  },
+  {
+    type: 'diamond',
+    spawnChance: 0.11,
+    reward: { type: 'unminted_hash', value: 0.000000032 },
+    sprite: { name: 'Auric Spire', image: objectSprite10, size: 138 },
+  },
+  {
+    type: 'wheel',
+    spawnChance: 0.1,
+    reward: { type: 'mini_game', label: 'Wheel Spin' },
+    sprite: { name: 'Spin Catalyst', image: objectSprite11, size: 134 },
+  },
+  {
+    type: 'slot',
+    spawnChance: 0.1,
+    reward: { type: 'mini_game', label: 'Slot Rush' },
+    sprite: { name: 'Slot Matrix', image: objectSprite12, size: 126 },
+  },
+  {
+    type: 'plinko',
+    spawnChance: 0.1,
+    reward: { type: 'mini_game', label: 'Plinko Drop' },
+    sprite: { name: 'Plinko Cradle', image: objectSprite13, size: 132 },
+  },
+  {
+    type: 'vault',
+    spawnChance: 0.1,
+    reward: { type: 'unminted_hash', value: 0.00000005 },
+    sprite: { name: 'Hash Vault Core', image: objectSprite14, size: 148 },
+  },
 ];
 
 let nextObjectId = 1;
@@ -51,6 +132,17 @@ const miniGameRewardSequence = [0.00000002, 0.000000035, 0.00000005, 0.0000001];
 
 let spawnCursor = 0;
 
+const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
+
+const createMotion = (): ObjectMotion => ({
+  x: randomBetween(12, 88),
+  y: randomBetween(14, 86),
+  floatDuration: randomBetween(6, 11),
+  floatDelay: randomBetween(-6, 0),
+  driftX: randomBetween(-18, 18),
+  driftY: randomBetween(-12, 12),
+});
+
 const createObject = (): ActiveObject => {
   const definition = spawnTable[spawnCursor % spawnTable.length];
   spawnCursor += 1;
@@ -59,6 +151,7 @@ const createObject = (): ActiveObject => {
     ...definition,
     id,
     health: definition.type === 'vault' ? 3 : 1,
+    motion: createMotion(),
   };
 };
 
@@ -92,6 +185,8 @@ type GameState = {
   resolveMiniGame: () => void;
   settleDailyMint: () => void;
   tradeInForHash: (amount: number) => void;
+  syncBackendBalances: (payload: { hashBalance: number | string; unmintedHash: number | string }) => void;
+  addEvent: (message: string) => void;
 };
 
 const pushEvent = (events: EventEntry[], message: string): EventEntry[] => {
@@ -128,7 +223,10 @@ export const useGameStore = create<GameState>()(
 
         if (target.reward.type === 'unminted_hash') {
           balances.unminted = Number((balances.unminted + target.reward.value).toFixed(10));
-          events = pushEvent(events, `Destroyed ${target.type} for ${target.reward.value.toFixed(10)} unminted HASH.`);
+          events = pushEvent(
+            events,
+            `Destroyed ${target.sprite.name} for ${target.reward.value.toFixed(10)} unminted HASH.`,
+          );
         } else {
           const payout = miniGameRewardSequence[nextMiniGameIndex % miniGameRewardSequence.length];
           nextMiniGameIndex += 1;
@@ -137,7 +235,10 @@ export const useGameStore = create<GameState>()(
             payout,
             status: 'pending',
           };
-          events = pushEvent(events, `${target.reward.label} ready! Resolve to claim ${payout.toFixed(10)} HASH.`);
+          events = pushEvent(
+            events,
+            `${target.sprite.name} triggered ${target.reward.label}! Resolve to claim ${payout.toFixed(10)} HASH.`,
+          );
         }
 
         return {
@@ -205,6 +306,30 @@ export const useGameStore = create<GameState>()(
           events,
         };
       }, false, 'tradeInForHash');
+    },
+    syncBackendBalances: ({ hashBalance, unmintedHash }) => {
+      const parse = (value: number | string) => {
+        const numeric = typeof value === 'string' ? Number(value) : value;
+        if (!Number.isFinite(numeric)) {
+          return 0;
+        }
+        return Number(numeric.toFixed(10));
+      };
+
+      set((state) => ({
+        ...state,
+        balances: {
+          ...state.balances,
+          hash: parse(hashBalance),
+          unminted: parse(unmintedHash),
+        },
+      }), false, 'syncBackendBalances');
+    },
+    addEvent: (message) => {
+      set((state) => ({
+        ...state,
+        events: pushEvent(state.events, message),
+      }), false, 'addEvent');
     },
   }))
 );

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",
+    "noEmit": true,
     "types": ["vite/client"]
   },
   "include": ["src"],


### PR DESCRIPTION
## What changed and why
- replace the grid of placeholder modules with animated sprite buttons sourced from the uploaded images so players click on floating objects instead of cards
- embed sprite metadata in the game store to control spawn visuals, motion, and event copy aligned with the backend destroy flow
- refresh the game board styling to showcase the animated field and provide hover/focus captions with reward info

## Any schema or API changes?
- None

## How to test locally
- pnpm -C frontend build

## Screenshots for UI
- Unable to capture within the container because installing dependencies from npm is blocked (403 from registry).


------
https://chatgpt.com/codex/tasks/task_e_68dc651e8728832e89860be9887a7d5b