### PR TITLE
Allow www.hashequity.com in Vite preview

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  preview: {
+    allowedHosts: ['www.hashequity.com'],
+  },
 });


### PR DESCRIPTION
## Summary
- allow the production domain in the Vite preview configuration so the site can load when served through the preview server

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea93d8e08832eaa1bae21c6e2020e