### PR TITLE
Replace board cards with animated coin collectibles

### DIFF
--- a/HashEquity Objects/README.md
+++ b/HashEquity Objects/README.md
@@ -1,0 +1,18 @@
+# HashEquity Object Art
+
+The interactive coin art used on the HashEquity game board now lives under `frontend/src/assets/coins` where the Vite bundler can import it directly.
+
+This directory is kept to document the available coin objects and provide a quick reference to the canonical filenames:
+
+- `hash-core.svg`
+- `prism-spark.svg`
+- `quantum-lattice.svg`
+- `flux-prism.svg`
+- `forge-block.svg`
+- `nova-gem.svg`
+- `wheel-token.svg`
+- `jackpot-chip.svg`
+- `plinko-disc.svg`
+- `vault-emblem.svg`
+
+When adding new objects, drop the source art here and copy it into `frontend/src/assets/coins` so it can be bundled with the frontend app.

--- a/frontend/src/assets/coins/flux-prism.svg
+++ b/frontend/src/assets/coins/flux-prism.svg
@@ -1,0 +1,20 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="flux-prism-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFF2F9" />
+      <stop offset="40%" stop-color="#FF8FE3" />
+      <stop offset="100%" stop-color="#AB2F92" />
+    </radialGradient>
+    <linearGradient id="flux-prism-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFC8F2" />
+      <stop offset="100%" stop-color="#7A1F6A" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#flux-prism-ring)" opacity="0.9" />
+  <circle cx="90" cy="90" r="62" fill="url(#flux-prism-glow)" />
+  <path d="M90 38L134 90L90 142L46 90L90 38Z" fill="#340B38" opacity="0.55" />
+  <path d="M90 54L120 90L90 126L60 90L90 54Z" fill="#FFCAF2" opacity="0.55" />
+  <path d="M90 66L110 90L90 114L70 90L90 66Z" fill="#D63BC2" opacity="0.9" />
+  <path d="M90 74L104 90L90 106L76 90L90 74Z" fill="#FFDFF8" />
+  <path d="M90 82L98 90L90 98L82 90L90 82Z" fill="#FFFAFB" />
+</svg>

--- a/frontend/src/assets/coins/forge-block.svg
+++ b/frontend/src/assets/coins/forge-block.svg
@@ -1,0 +1,20 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="forge-block-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#F3FBFF" />
+      <stop offset="45%" stop-color="#7DE3FF" />
+      <stop offset="100%" stop-color="#15647D" />
+    </radialGradient>
+    <linearGradient id="forge-block-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#A5F3FF" />
+      <stop offset="100%" stop-color="#0D4E61" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#forge-block-ring)" opacity="0.9" />
+  <circle cx="90" cy="90" r="64" fill="url(#forge-block-glow)" />
+  <rect x="58" y="58" width="64" height="64" rx="14" fill="#0E3843" opacity="0.55" />
+  <rect x="64" y="64" width="52" height="52" rx="12" fill="#BDF2FF" opacity="0.55" />
+  <rect x="70" y="70" width="40" height="40" rx="10" fill="#138AA9" opacity="0.85" />
+  <rect x="76" y="76" width="28" height="28" rx="8" fill="#ECFCFF" />
+  <path d="M90 80L100 90L90 100L80 90L90 80Z" fill="#0B4E62" opacity="0.8" />
+</svg>

--- a/frontend/src/assets/coins/hash-core.svg
+++ b/frontend/src/assets/coins/hash-core.svg
@@ -1,0 +1,20 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="hash-core-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFF4C5" />
+      <stop offset="45%" stop-color="#FFD46A" />
+      <stop offset="100%" stop-color="#D18C1C" />
+    </radialGradient>
+    <linearGradient id="hash-core-ring" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFF6D2" />
+      <stop offset="100%" stop-color="#C67A14" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#hash-core-ring)" opacity="0.9" />
+  <circle cx="90" cy="90" r="68" fill="url(#hash-core-glow)" />
+  <path d="M90 38L118 52L132 80L118 108L90 122L62 108L48 80L62 52L90 38Z" fill="#FFF7DF" opacity="0.4" />
+  <path d="M90 56L109 66L119 90L109 114L90 124L71 114L61 90L71 66L90 56Z" fill="#8F4A04" opacity="0.5" />
+  <circle cx="90" cy="90" r="30" fill="#FFFAE9" opacity="0.75" />
+  <path d="M90 68L104 90L90 112L76 90L90 68Z" fill="#E6A220" opacity="0.8" />
+  <circle cx="90" cy="90" r="14" fill="#FFF6D2" />
+</svg>

--- a/frontend/src/assets/coins/jackpot-chip.svg
+++ b/frontend/src/assets/coins/jackpot-chip.svg
@@ -1,0 +1,20 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="jackpot-chip-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFEFF7" />
+      <stop offset="40%" stop-color="#FF7CBE" />
+      <stop offset="100%" stop-color="#A01352" />
+    </radialGradient>
+    <linearGradient id="jackpot-chip-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFB9DC" />
+      <stop offset="100%" stop-color="#790D3D" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#jackpot-chip-ring)" opacity="0.92" />
+  <circle cx="90" cy="90" r="66" fill="url(#jackpot-chip-glow)" />
+  <circle cx="90" cy="90" r="50" fill="#360213" opacity="0.55" />
+  <circle cx="90" cy="90" r="38" fill="#FFD6EC" opacity="0.6" />
+  <rect x="78" y="62" width="24" height="56" rx="12" fill="#C21F62" opacity="0.85" />
+  <rect x="70" y="80" width="40" height="20" rx="10" fill="#FFF2FA" />
+  <path d="M72 92H108" stroke="#8E1146" stroke-width="4" stroke-linecap="round" />
+</svg>

--- a/frontend/src/assets/coins/nova-gem.svg
+++ b/frontend/src/assets/coins/nova-gem.svg
@@ -1,0 +1,20 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="nova-gem-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFF0F3" />
+      <stop offset="40%" stop-color="#FF9BA8" />
+      <stop offset="100%" stop-color="#B32744" />
+    </radialGradient>
+    <linearGradient id="nova-gem-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFC4CE" />
+      <stop offset="100%" stop-color="#6D1128" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#nova-gem-ring)" opacity="0.9" />
+  <circle cx="90" cy="90" r="64" fill="url(#nova-gem-glow)" />
+  <path d="M90 32L132 72L120 128L90 152L60 128L48 72L90 32Z" fill="#470717" opacity="0.55" />
+  <path d="M90 52L120 78L110 120L90 136L70 120L60 78L90 52Z" fill="#FFCED7" opacity="0.55" />
+  <path d="M90 70L108 86L102 112L90 122L78 112L72 86L90 70Z" fill="#F25D76" opacity="0.88" />
+  <path d="M90 82L102 92L99 108L90 116L81 108L78 92L90 82Z" fill="#FFE6EA" />
+  <circle cx="90" cy="100" r="10" fill="#FFFAFB" />
+</svg>

--- a/frontend/src/assets/coins/plinko-disc.svg
+++ b/frontend/src/assets/coins/plinko-disc.svg
@@ -1,0 +1,26 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="plinko-disc-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#ECFFF6" />
+      <stop offset="40%" stop-color="#5FF7B5" />
+      <stop offset="100%" stop-color="#15804D" />
+    </radialGradient>
+    <linearGradient id="plinko-disc-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9BFAD4" />
+      <stop offset="100%" stop-color="#0B5C37" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#plinko-disc-ring)" opacity="0.92" />
+  <circle cx="90" cy="90" r="66" fill="url(#plinko-disc-glow)" />
+  <circle cx="90" cy="90" r="48" fill="#083624" opacity="0.55" />
+  <circle cx="90" cy="90" r="34" fill="#B3FDE1" opacity="0.7" />
+  <g opacity="0.9">
+    <circle cx="90" cy="66" r="6" fill="#0B6B41" />
+    <circle cx="112" cy="90" r="6" fill="#0B6B41" />
+    <circle cx="90" cy="114" r="6" fill="#0B6B41" />
+    <circle cx="68" cy="90" r="6" fill="#0B6B41" />
+    <circle cx="102" cy="78" r="6" fill="#0B6B41" />
+    <circle cx="78" cy="102" r="6" fill="#0B6B41" />
+  </g>
+  <circle cx="90" cy="90" r="14" fill="#EBFFF7" />
+</svg>

--- a/frontend/src/assets/coins/prism-spark.svg
+++ b/frontend/src/assets/coins/prism-spark.svg
@@ -1,0 +1,20 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="prism-spark-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#EAFBFF" />
+      <stop offset="45%" stop-color="#62E6FF" />
+      <stop offset="100%" stop-color="#0C84B6" />
+    </radialGradient>
+    <linearGradient id="prism-spark-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#A9F2FF" />
+      <stop offset="100%" stop-color="#0A6B98" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#prism-spark-ring)" opacity="0.92" />
+  <circle cx="90" cy="90" r="66" fill="url(#prism-spark-glow)" />
+  <path d="M90 34L138 90L90 146L42 90L90 34Z" fill="#072944" opacity="0.55" />
+  <path d="M90 52L120 90L90 128L60 90L90 52Z" fill="#6AF1FF" opacity="0.45" />
+  <path d="M90 64L110 90L90 116L70 90L90 64Z" fill="#1B8DD4" />
+  <circle cx="90" cy="90" r="18" fill="#B9F6FF" opacity="0.8" />
+  <circle cx="90" cy="90" r="8" fill="#F4FEFF" />
+</svg>

--- a/frontend/src/assets/coins/quantum-lattice.svg
+++ b/frontend/src/assets/coins/quantum-lattice.svg
@@ -1,0 +1,20 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="quantum-lattice-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#F4EBFF" />
+      <stop offset="40%" stop-color="#C294FF" />
+      <stop offset="100%" stop-color="#5420A1" />
+    </radialGradient>
+    <linearGradient id="quantum-lattice-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#D9B7FF" />
+      <stop offset="100%" stop-color="#451580" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#quantum-lattice-ring)" opacity="0.92" />
+  <circle cx="90" cy="90" r="64" fill="url(#quantum-lattice-glow)" />
+  <path d="M54 72L90 52L126 72V108L90 128L54 108V72Z" fill="#2F0E6A" opacity="0.6" />
+  <path d="M90 60L118 76V104L90 120L62 104V76L90 60Z" fill="#CDA7FF" opacity="0.5" />
+  <path d="M90 70L110 82V98L90 110L70 98V82L90 70Z" fill="#742DD4" />
+  <path d="M90 76L104 84V96L90 104L76 96V84L90 76Z" fill="#E9D3FF" opacity="0.75" />
+  <circle cx="90" cy="90" r="10" fill="#F9F3FF" />
+</svg>

--- a/frontend/src/assets/coins/vault-emblem.svg
+++ b/frontend/src/assets/coins/vault-emblem.svg
@@ -1,0 +1,21 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="vault-emblem-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#F5F8FF" />
+      <stop offset="40%" stop-color="#9EB9FF" />
+      <stop offset="100%" stop-color="#2443A9" />
+    </radialGradient>
+    <linearGradient id="vault-emblem-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#B8C9FF" />
+      <stop offset="100%" stop-color="#132065" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#vault-emblem-ring)" opacity="0.94" />
+  <circle cx="90" cy="90" r="66" fill="url(#vault-emblem-glow)" />
+  <circle cx="90" cy="90" r="54" fill="#0E1A52" opacity="0.55" />
+  <circle cx="90" cy="90" r="40" fill="#D8E2FF" opacity="0.6" />
+  <path d="M90 58L116 74V106L90 122L64 106V74L90 58Z" fill="#2C49B6" opacity="0.75" />
+  <path d="M90 66L108 78V102L90 114L72 102V78L90 66Z" fill="#9EB4FF" />
+  <circle cx="90" cy="90" r="14" fill="#152670" />
+  <path d="M90 80L96 90L90 100L84 90L90 80Z" fill="#BFD1FF" />
+</svg>

--- a/frontend/src/assets/coins/wheel-token.svg
+++ b/frontend/src/assets/coins/wheel-token.svg
@@ -1,0 +1,20 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="wheel-token-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFF8E7" />
+      <stop offset="40%" stop-color="#FCCE5A" />
+      <stop offset="100%" stop-color="#C75A0A" />
+    </radialGradient>
+    <linearGradient id="wheel-token-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFE2A8" />
+      <stop offset="100%" stop-color="#8E3600" />
+    </linearGradient>
+  </defs>
+  <circle cx="90" cy="90" r="82" fill="url(#wheel-token-ring)" opacity="0.92" />
+  <circle cx="90" cy="90" r="66" fill="url(#wheel-token-glow)" />
+  <circle cx="90" cy="90" r="52" fill="#2A0F00" opacity="0.55" />
+  <circle cx="90" cy="90" r="40" fill="#FBE2B0" opacity="0.6" />
+  <circle cx="90" cy="90" r="28" fill="#E47B0F" opacity="0.85" />
+  <circle cx="90" cy="90" r="14" fill="#FFF3D5" />
+  <path d="M90 48L96 76L124 90L96 104L90 132L84 104L56 90L84 76L90 48Z" fill="#FFDCA1" opacity="0.8" />
+</svg>

--- a/frontend/src/components/GameBoard.module.css
+++ b/frontend/src/components/GameBoard.module.css
@@ -1,6 +1,70 @@
 .board {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
+  min-height: 520px;
+  padding: 2rem;
+  border-radius: 28px;
+  border: 1px solid rgba(128, 112, 255, 0.25);
+  background:
+    radial-gradient(circle at 18% 22%, rgba(120, 214, 255, 0.14), transparent 60%),
+    radial-gradient(circle at 82% 78%, rgba(255, 166, 253, 0.16), transparent 58%),
+    linear-gradient(135deg, rgba(16, 14, 42, 0.92), rgba(7, 6, 28, 0.94));
+  box-shadow: 0 34px 68px rgba(8, 4, 24, 0.55);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.board::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(
+      120deg,
+      rgba(120, 110, 220, 0.15) 0%,
+      transparent 55%,
+      rgba(78, 204, 255, 0.12) 100%
+    ),
+    repeating-linear-gradient(
+      0deg,
+      rgba(210, 218, 255, 0.08) 0px,
+      rgba(210, 218, 255, 0.08) 1px,
+      transparent 1px,
+      transparent 32px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(210, 218, 255, 0.08) 0px,
+      rgba(210, 218, 255, 0.08) 1px,
+      transparent 1px,
+      transparent 32px
+    );
+  opacity: 0.4;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.board::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.05), transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+@media (max-width: 768px) {
+  .board {
+    min-height: 460px;
+    padding: 1.4rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .board {
+    min-height: 400px;
+  }
 }

--- a/frontend/src/components/GameObjectCard.module.css
+++ b/frontend/src/components/GameObjectCard.module.css
@@ -1,177 +1,112 @@
-.card {
-  position: relative;
+.coin {
+  position: absolute;
+  border: none;
+  background: none;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 0.35rem;
-  width: 100%;
-  padding: 1rem 1.2rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(152, 132, 255, 0.25);
-  background: linear-gradient(160deg, rgba(57, 41, 124, 0.85), rgba(20, 16, 60, 0.92));
-  box-shadow: 0 20px 40px rgba(31, 20, 82, 0.25);
-  color: var(--text-primary, #f5f8ff);
+  align-items: center;
+  gap: 0.45rem;
+  transform: translate(-50%, -50%);
   cursor: pointer;
-  text-align: left;
-  text-transform: capitalize;
-  overflow: hidden;
-  transform: translateY(0);
+  color: var(--text-primary, #f5f8ff);
+  text-shadow: 0 4px 18px rgba(6, 6, 20, 0.5);
+  animation-name: coinFloat;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  filter: drop-shadow(0 18px 28px rgba(9, 6, 26, 0.45));
   transition:
     transform 0.35s ease,
-    box-shadow 0.35s ease,
-    border-color 0.35s ease;
-}
-
-.card::before,
-.card::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  opacity: 0;
-  transition: opacity 0.35s ease;
-  pointer-events: none;
-}
-
-.card::before {
-  background: radial-gradient(circle at 20% 20%, rgba(187, 141, 255, 0.38), transparent 55%);
-  filter: blur(0.8px);
-}
-
-.card::after {
-  background: radial-gradient(circle at 80% 80%, rgba(111, 226, 255, 0.4), transparent 60%);
-  mix-blend-mode: screen;
-}
-
-.card:hover {
-  transform: translateY(-6px);
-  border-color: rgba(187, 141, 255, 0.55);
-  box-shadow: 0 28px 54px rgba(62, 36, 160, 0.45);
-}
-
-.card:hover::before,
-.card:hover::after {
-  opacity: 1;
-}
-
-.card:focus-visible {
-  outline: 2px solid rgba(166, 132, 255, 0.65);
-  outline-offset: 3px;
-}
-
-.cardContent {
-  position: relative;
+    filter 0.35s ease;
   z-index: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  width: 100%;
 }
 
-.sparkles {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
+.coin:hover,
+.coin:focus-visible {
+  animation-play-state: paused;
+  transform: translate(-50%, -52%) scale(1.05);
+  filter: drop-shadow(0 26px 36px rgba(32, 18, 82, 0.55));
 }
 
-.label {
-  font-weight: 700;
-  font-size: 1rem;
-  letter-spacing: 0.03em;
-}
-
-.reward {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: rgba(213, 235, 255, 0.78);
-}
-
-.meta {
-  font-size: 0.78rem;
-  color: rgba(199, 206, 255, 0.58);
-}
-
-.cardFloating {
-  animation: collectibleFloat 4.8s ease-in-out infinite;
-}
-
-.cardFloating:hover {
+.coin:active {
+  transform: translate(-50%, -48%) scale(0.96);
   animation-play-state: paused;
 }
 
-.cardGlint {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background:
-    conic-gradient(from 120deg at 50% 50%, rgba(255, 255, 255, 0.18), transparent 30%, rgba(111, 226, 255, 0.12) 60%, transparent 80%);
-  opacity: 0;
-  transform: rotate(0deg) scale(1.1);
-  transition:
-    opacity 0.5s ease,
-    transform 1.4s ease;
-  mix-blend-mode: screen;
-  pointer-events: none;
-  z-index: 0;
+.coin:focus-visible {
+  outline: 2px solid rgba(166, 132, 255, 0.85);
+  outline-offset: 6px;
 }
 
-.card:hover .cardGlint {
-  opacity: 0.65;
-  transform: rotate(12deg) scale(1.18);
+.small {
+  width: min(24vw, 120px);
 }
 
-.sparkles .sparkle {
-  position: absolute;
-  width: 12px;
-  height: 12px;
+.medium {
+  width: min(26vw, 150px);
+}
+
+.large {
+  width: min(32vw, 180px);
+}
+
+.art {
+  width: 100%;
+  height: auto;
+  display: block;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
-  opacity: 0;
-  animation: sparkle 6s linear infinite;
-  pointer-events: none;
+  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.6), transparent 60%);
 }
 
-.sparkles .sparkle:nth-child(1) {
-  top: 14%;
-  left: 78%;
-  animation-delay: 0.4s;
+.hud {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.35rem 0.85rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(10, 12, 40, 0.78);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 16px 40px rgba(8, 6, 32, 0.55);
+  text-align: center;
 }
 
-.sparkles .sparkle:nth-child(2) {
-  bottom: 18%;
-  right: 22%;
-  animation-delay: 1.7s;
+.name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
 }
 
-.sparkles .sparkle:nth-child(3) {
-  top: 36%;
-  right: 8%;
-  animation-delay: 3s;
+.reward {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: rgba(199, 235, 255, 0.88);
 }
 
-@keyframes collectibleFloat {
+.health {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(188, 198, 255, 0.65);
+}
+
+@keyframes coinFloat {
   0%,
   100% {
-    transform: translateY(0);
+    transform: translate(-50%, -50%) translateY(0);
   }
   50% {
-    transform: translateY(-10px);
+    transform: translate(-50%, calc(-50% - 18px));
   }
 }
 
-@keyframes sparkle {
-  0%,
-  100% {
-    opacity: 0;
-    transform: scale(0.4) translate3d(0, 0, 0);
+@media (prefers-reduced-motion: reduce) {
+  .coin {
+    animation: none;
   }
-  40% {
-    opacity: 1;
-    transform: scale(1) translate3d(-4px, -6px, 0);
-  }
-  60% {
-    opacity: 0.6;
-    transform: scale(0.7) translate3d(6px, 4px, 0);
+
+  .coin:hover,
+  .coin:focus-visible {
+    transform: translate(-50%, -50%) scale(1.05);
   }
 }

--- a/frontend/src/state/gameTypes.ts
+++ b/frontend/src/state/gameTypes.ts
@@ -1,0 +1,33 @@
+export type RewardDefinition =
+  | {
+      type: 'unminted_hash';
+      value: number;
+    }
+  | {
+      type: 'mini_game';
+      label: string;
+    };
+
+export type GameObjectType =
+  | 'circle'
+  | 'triangle'
+  | 'hexagon'
+  | 'prism'
+  | 'cube'
+  | 'diamond'
+  | 'wheel'
+  | 'slot'
+  | 'plinko'
+  | 'vault';
+
+export type GameObjectSize = 'small' | 'medium' | 'large';
+
+export type SpawnDefinition = {
+  type: GameObjectType;
+  name: string;
+  spawnChance: number;
+  reward: RewardDefinition;
+  image: string;
+  size: GameObjectSize;
+  health: number;
+};

--- a/frontend/src/state/spawnDefinitions.ts
+++ b/frontend/src/state/spawnDefinitions.ts
@@ -1,0 +1,104 @@
+import hashCore from '../assets/coins/hash-core.svg';
+import prismSpark from '../assets/coins/prism-spark.svg';
+import quantumLattice from '../assets/coins/quantum-lattice.svg';
+import fluxPrism from '../assets/coins/flux-prism.svg';
+import forgeBlock from '../assets/coins/forge-block.svg';
+import novaGem from '../assets/coins/nova-gem.svg';
+import wheelToken from '../assets/coins/wheel-token.svg';
+import jackpotChip from '../assets/coins/jackpot-chip.svg';
+import plinkoDisc from '../assets/coins/plinko-disc.svg';
+import vaultEmblem from '../assets/coins/vault-emblem.svg';
+import type { SpawnDefinition } from './gameTypes';
+
+export const spawnDefinitions: SpawnDefinition[] = [
+  {
+    type: 'circle',
+    name: 'Hash Core',
+    image: hashCore,
+    size: 'medium',
+    spawnChance: 0.18,
+    reward: { type: 'unminted_hash', value: 0.00000001 },
+    health: 1,
+  },
+  {
+    type: 'triangle',
+    name: 'Prism Spark',
+    image: prismSpark,
+    size: 'small',
+    spawnChance: 0.12,
+    reward: { type: 'unminted_hash', value: 0.000000014 },
+    health: 1,
+  },
+  {
+    type: 'hexagon',
+    name: 'Quantum Lattice',
+    image: quantumLattice,
+    size: 'large',
+    spawnChance: 0.1,
+    reward: { type: 'unminted_hash', value: 0.000000018 },
+    health: 1,
+  },
+  {
+    type: 'prism',
+    name: 'Flux Prism',
+    image: fluxPrism,
+    size: 'small',
+    spawnChance: 0.08,
+    reward: { type: 'unminted_hash', value: 0.00000002 },
+    health: 1,
+  },
+  {
+    type: 'cube',
+    name: 'Forge Block',
+    image: forgeBlock,
+    size: 'medium',
+    spawnChance: 0.07,
+    reward: { type: 'unminted_hash', value: 0.000000024 },
+    health: 1,
+  },
+  {
+    type: 'diamond',
+    name: 'Nova Gem',
+    image: novaGem,
+    size: 'medium',
+    spawnChance: 0.1,
+    reward: { type: 'unminted_hash', value: 0.00000003 },
+    health: 1,
+  },
+  {
+    type: 'wheel',
+    name: 'Wheel Token',
+    image: wheelToken,
+    size: 'large',
+    spawnChance: 0.12,
+    reward: { type: 'mini_game', label: 'Wheel Spin' },
+    health: 1,
+  },
+  {
+    type: 'slot',
+    name: 'Jackpot Chip',
+    image: jackpotChip,
+    size: 'medium',
+    spawnChance: 0.08,
+    reward: { type: 'mini_game', label: 'Slot Rush' },
+    health: 1,
+  },
+  {
+    type: 'plinko',
+    name: 'Plinko Disc',
+    image: plinkoDisc,
+    size: 'small',
+    spawnChance: 0.08,
+    reward: { type: 'mini_game', label: 'Plinko Drop' },
+    health: 1,
+  },
+  {
+    type: 'vault',
+    name: 'Vault Emblem',
+    image: vaultEmblem,
+    size: 'large',
+    spawnChance: 0.07,
+    reward: { type: 'unminted_hash', value: 0.00000005 },
+    health: 3,
+  },
+];

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  preview: {
+    allowedHosts: ['www.hashequity.com'],
+  },
 });


### PR DESCRIPTION
## Summary
- add a dedicated coin art library that mirrors the HashEquity object set and make it available to the frontend build
- refactor the game store to spawn floating coin collectibles with weighted probabilities, positions, and health tracking
- redesign the game board surface and coin component styling to showcase the new assets and hover states

## What changed and why
- moved the coin artwork into `frontend/src/assets/coins` so the new Vite build can import real assets instead of placeholder cards
- restructured the Zustand game store to choose spawn definitions via weights, randomize placement/animation, and gate backend sync until a coin is fully destroyed
- rebuilt the board and coin styling so players now click animated HashEquity coins rather than generic cards, aligning the UI with the uploaded art direction

## Any schema or API changes?
- None.

## How to test locally
- npm install
- npm run dev -- --host 0.0.0.0 --port 4173

## Screenshots for UI
- ![Floating HashEquity coins on the refreshed game board](browser:/invocations/vrhhmytz/artifacts/artifacts/coin-game.png)

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dea93d8e08832eaa1bae21c6e2020e