### PR TITLE
Fix EconomyPanel daily mint selector

### DIFF
--- a/frontend/src/components/EconomyPanel.tsx
+++ b/frontend/src/components/EconomyPanel.tsx
@@ -17,6 +17,7 @@ export const EconomyPanel = () => {
   const addEvent = useGameStore((state) => state.addEvent);
   const { hash, unminted, vault } = useGameStore((state) => state.balances);
   const tradeInForHash = useGameStore((state) => state.tradeInForHash);
+  const settleDailyMint = useGameStore((state) => state.settleDailyMint);
   const [tradeAmount, setTradeAmount] = useState('0.00000000');
 
   const fillMaxTrade = () => {


### PR DESCRIPTION
## Summary
- add the settleDailyMint selector in EconomyPanel so the mint mutation can update the store

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc7c1ad3c832e85be339e11a3a60a