### PR TITLE
fix: harden wallet normalization guardrails

### DIFF
--- a/backend/config/admin.js
+++ b/backend/config/admin.js
@@ -2,7 +2,18 @@ const DEFAULT_ADMIN_WALLETS = [
   "0xCd0Bc675455ee5Fa8739F5c377fe4Ec1437Bc618"
 ];
 
-const normalizeWallet = (wallet = "") => wallet.trim().toLowerCase();
+const normalizeWallet = (wallet) => {
+  if (typeof wallet !== "string") {
+    return "";
+  }
+
+  const trimmed = wallet.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  return trimmed.toLowerCase();
+};
 
 const loadAdminWallets = () => {
   const fromEnv = process.env.ADMIN_WALLETS;

--- a/backend/controllers/gameController.js
+++ b/backend/controllers/gameController.js
@@ -80,6 +80,10 @@ exports.destroyObject = async (req, res) => {
 
     const normalizedWallet = normalizeWallet(wallet);
 
+    if (!normalizedWallet) {
+      return res.status(400).json({ error: "Missing wallet" });
+    }
+
     const numericReward = toNumber(reward);
 
     const userUpdate = {


### PR DESCRIPTION
## Summary
- guard wallet normalization against non-string inputs before trimming
- reject destroy requests that normalize to empty wallets to avoid invalid records

## Testing
- not run (backend has no automated test suite)

------
https://chatgpt.com/codex/tasks/task_e_68dfffd91300832e8904d705cc19df4e