### PR TITLE
Remove telemetry feed and limit object click area

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import { GameBoard } from './components/GameBoard';
 import { EconomyPanel } from './components/EconomyPanel';
 import { MiniGamePanel } from './components/MiniGamePanel';
-import { EventFeed } from './components/EventFeed';
 import { TopBar } from './components/TopBar';
 import { StatsPanel } from './components/StatsPanel';
 import styles from './App.module.css';
@@ -17,7 +16,6 @@ export const App = () => (
       <aside className={styles.sidebar}>
         <EconomyPanel />
         <StatsPanel />
-        <EventFeed />
       </aside>
     </main>
   </div>

--- a/frontend/src/components/GameObjectCard.module.css
+++ b/frontend/src/components/GameObjectCard.module.css
@@ -3,7 +3,9 @@
   border: none;
   background: none;
   padding: 0;
-  display: block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transform: translate(-50%, -50%);
   cursor: pointer;
   animation-name: coinFloat;
@@ -12,6 +14,9 @@
   transition:
     transform 0.35s ease;
   z-index: 1;
+  border-radius: 50%;
+  overflow: hidden;
+  clip-path: circle(50%);
 }
 
 .coin:hover,
@@ -47,7 +52,7 @@
   height: auto;
   display: block;
   border-radius: 50%;
-  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.6), transparent 60%);
+  background: none;
 }
 
 @keyframes coinFloat {


### PR DESCRIPTION
## Summary
- remove the telemetry event feed from the sidebar layout
- confine game object hit areas to the visible art and drop the glow background

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0254b9668832eb998101812907e57