### PR TITLE
Add player destroy count tracking

### DIFF
--- a/backend/controllers/gameController.js
+++ b/backend/controllers/gameController.js
@@ -44,7 +44,8 @@ exports.getBalances = async (req, res) => {
 
     res.json({
       hashBalance: toNumber(user?.hashBalance),
-      unmintedHash: toNumber(user?.unmintedHash)
+      unmintedHash: toNumber(user?.unmintedHash),
+      objectsDestroyed: toNumber(user?.objectsDestroyed)
     });
   } catch (err) {
     console.error("Balance fetch error:", err);
@@ -69,11 +70,12 @@ exports.destroyObject = async (req, res) => {
     const numericReward = toNumber(reward);
 
     const userUpdate = {
-      $setOnInsert: { walletAddress: normalizedWallet }
+      $setOnInsert: { walletAddress: normalizedWallet },
+      $inc: { objectsDestroyed: 1 }
     };
 
     if (numericReward !== 0) {
-      userUpdate.$inc = { unmintedHash: numericReward };
+      userUpdate.$inc.unmintedHash = numericReward;
     }
 
     const user = await User.findOneAndUpdate(
@@ -102,7 +104,8 @@ exports.destroyObject = async (req, res) => {
 
     res.json({
       hashBalance: toNumber(user?.hashBalance),
-      unmintedHash: toNumber(user?.unmintedHash)
+      unmintedHash: toNumber(user?.unmintedHash),
+      objectsDestroyed: toNumber(user?.objectsDestroyed)
     });
   } catch (err) {
     console.error("Destroy error:", err);
@@ -148,6 +151,7 @@ exports.tradeInForHash = async (req, res) => {
     res.json({
       hashBalance: updatedHashBalance,
       unmintedHash: updatedUnminted,
+      objectsDestroyed: toNumber(user?.objectsDestroyed),
       tradedAmount: tradeAmount,
       mintedAmount,
     });

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -11,6 +11,7 @@ const userSchema = new mongoose.Schema(
     },
     unmintedHash: { type: Number, default: 0 },
     hashBalance: { type: Number, default: 0 },
+    objectsDestroyed: { type: Number, default: 0 },
     isAdmin: { type: Boolean, default: false }
   },
   { timestamps: true }

--- a/frontend/src/components/EconomyPanel.tsx
+++ b/frontend/src/components/EconomyPanel.tsx
@@ -9,7 +9,12 @@ export const EconomyPanel = () => {
   const { address } = useAccount();
   const syncBackendBalances = useGameStore((state) => state.syncBackendBalances);
   const addEvent = useGameStore((state) => state.addEvent);
-  const { hash, unminted, vault } = useGameStore((state) => state.balances);
+  const { hash, unminted, vault, objectsDestroyed } = useGameStore((state) => ({
+    hash: state.balances.hash,
+    unminted: state.balances.unminted,
+    vault: state.balances.vault,
+    objectsDestroyed: state.objectsDestroyed,
+  }));
   const tradeInForHash = useGameStore((state) => state.tradeInForHash);
   const [tradeAmount, setTradeAmount] = useState('0.00000000');
 
@@ -30,6 +35,7 @@ export const EconomyPanel = () => {
       syncBackendBalances({
         hashBalance: result.hashBalance,
         unmintedHash: result.unmintedHash,
+        objectsDestroyed: result.objectsDestroyed,
       });
       tradeInForHash({ tradedAmount: result.tradedAmount, mintedAmount: result.mintedAmount });
       setTradeAmount('0.00000000');
@@ -44,6 +50,7 @@ export const EconomyPanel = () => {
       syncBackendBalances({
         hashBalance: data.hashBalance,
         unmintedHash: data.unmintedHash,
+        objectsDestroyed: data.objectsDestroyed,
       });
     }
   }, [data, syncBackendBalances]);
@@ -96,6 +103,10 @@ export const EconomyPanel = () => {
         <div>
           <dt>Vault</dt>
           <dd>{vault.toFixed(10)}</dd>
+        </div>
+        <div>
+          <dt>Objects Destroyed</dt>
+          <dd>{objectsDestroyed.toLocaleString()}</dd>
         </div>
       </dl>
       <div className={styles.actions}>

--- a/frontend/src/components/GameObjectCard.tsx
+++ b/frontend/src/components/GameObjectCard.tsx
@@ -22,6 +22,7 @@ export const GameObjectCard = ({ object }: Props) => {
       syncBackendBalances({
         hashBalance: balances.hashBalance,
         unmintedHash: balances.unmintedHash,
+        objectsDestroyed: balances.objectsDestroyed,
       });
       addEvent(`Backend recorded destroy for ${variables.objectId}. Balances synced.`);
     },

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -10,6 +10,7 @@ type StatsEntry = {
 type BalancesResponse = {
   hashBalance: number | string;
   unmintedHash: number | string;
+  objectsDestroyed: number | string;
 };
 
 type DestroyPayload = {


### PR DESCRIPTION
## Summary
- add an `objectsDestroyed` field to the User schema and ensure destroy, balances, and trade responses include it
- increment the destroy counter when recording a destroy event
- extend the frontend API types, store, and economy panel to display the signed-in wallet's destroy count

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07ef6cd3c832e8dc017e1106b50ef