### PR TITLE
Revamp HashEquity front-end experience

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -1,29 +1,258 @@
-.app {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem;
+.page {
+  position: relative;
+  min-height: 100vh;
+  padding: 1.5rem clamp(1.5rem, 5vw, 3.25rem) 4rem;
+  overflow: hidden;
 }
 
-.mainContent {
+.page::before,
+.page::after {
+  content: '';
+  position: fixed;
+  inset: -40vmax;
+  background: radial-gradient(circle at 25% 25%, rgba(255, 209, 90, 0.18), transparent 60%);
+  z-index: -2;
+  pointer-events: none;
+}
+
+.page::after {
+  background: radial-gradient(circle at 78% 18%, rgba(84, 163, 255, 0.22), transparent 62%);
+  mix-blend-mode: screen;
+}
+
+.hero {
   display: grid;
-  grid-template-columns: 2.2fr 1fr;
-  gap: 2rem;
+  grid-template-columns: minmax(0, 540px) minmax(260px, 1fr);
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto clamp(3.5rem, 8vw, 4.5rem);
+  position: relative;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: -20%;
+  border-radius: 32px;
+  background: linear-gradient(135deg, rgba(255, 189, 73, 0.16), rgba(84, 138, 255, 0.12));
+  filter: blur(80px);
+  opacity: 0.6;
+  z-index: -1;
+}
+
+.heroCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 194, 73, 0.16);
+  color: rgba(255, 222, 162, 0.85);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 4.6vw, 3.65rem);
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+}
+
+.hero p {
+  margin: 0;
+  color: rgba(244, 244, 255, 0.78);
+  font-size: clamp(1rem, 2vw, 1.1rem);
+  max-width: 36ch;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.primaryAction,
+.secondaryAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.7rem 1.5rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+.primaryAction {
+  background: linear-gradient(120deg, #ffd661, #ff8c42);
+  color: #110a02;
+  box-shadow: 0 12px 30px rgba(255, 170, 66, 0.32);
+}
+
+.primaryAction:hover,
+.primaryAction:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 34px rgba(255, 170, 66, 0.42);
+}
+
+.secondaryAction {
+  background: rgba(28, 34, 58, 0.7);
+  color: rgba(236, 243, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.secondaryAction:hover,
+.secondaryAction:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
+.heroStats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.heroStats div {
+  padding: 0.95rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(8, 12, 24, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 40px rgba(7, 10, 18, 0.35);
+  backdrop-filter: blur(14px);
+}
+
+.heroStats dt {
+  margin: 0 0 0.35rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(222, 228, 255, 0.7);
+}
+
+.heroStats dd {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #fff4d8;
+}
+
+.heroArt {
+  position: relative;
+  display: grid;
+  place-items: center;
+  aspect-ratio: 1 / 1;
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.glow {
+  position: absolute;
+  inset: 12%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 207, 112, 0.7), rgba(255, 95, 64, 0));
+  filter: blur(22px);
+  opacity: 0.85;
+}
+
+.primaryCoin {
+  width: 72%;
+  filter: drop-shadow(0 24px 35px rgba(255, 195, 102, 0.45));
+  z-index: 2;
+}
+
+.secondaryCoin {
+  position: absolute;
+  width: 46%;
+  top: 12%;
+  right: 4%;
+  opacity: 0.85;
+  filter: drop-shadow(0 16px 28px rgba(106, 193, 255, 0.35));
+}
+
+.tertiaryCoin {
+  position: absolute;
+  width: 38%;
+  bottom: 10%;
+  left: 0;
+  opacity: 0.7;
+  filter: drop-shadow(0 18px 32px rgba(255, 124, 198, 0.32));
+}
+
+.layout {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+  gap: clamp(1.75rem, 4vw, 2.25rem);
 }
 
 .primaryColumn {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1.5rem, 3vw, 1.9rem);
 }
 
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1.5rem, 3vw, 1.9rem);
+}
+
+.sidebar > div {
+  display: contents;
+}
+
+@media (max-width: 1080px) {
+  .hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .heroCopy {
+    align-items: center;
+  }
+
+  .hero p {
+    max-width: none;
+  }
+
+  .heroStats {
+    width: min(520px, 100%);
+    margin-inline: auto;
+  }
 }
 
 @media (max-width: 960px) {
-  .mainContent {
+  .layout {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding-inline: clamp(1rem, 4vw, 1.5rem);
+  }
+
+  .heroStats {
+    grid-template-columns: 1fr;
+  }
+
+  .heroArt {
+    max-width: 320px;
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,24 +1,87 @@
+import { useMemo } from 'react';
 import { GameBoard } from './components/GameBoard';
 import { EconomyPanel } from './components/EconomyPanel';
 import { MiniGamePanel } from './components/MiniGamePanel';
 import { TopBar } from './components/TopBar';
 import { StatsPanel } from './components/StatsPanel';
 import { LeaderboardPanel } from './components/LeaderboardPanel';
+import { useGameStore } from './state/gameStore';
+import heroCenter from './assets/coins/Object1-0.png';
+import heroOrbit from './assets/coins/Object0-6.png';
+import heroSignal from './assets/coins/Object0-3.png';
 import styles from './App.module.css';
 
-export const App = () => (
-  <div className={styles.app}>
-    <TopBar />
-    <main className={styles.mainContent}>
-      <div className={styles.primaryColumn}>
-        <GameBoard />
-        <LeaderboardPanel />
-        <MiniGamePanel />
-      </div>
-      <aside className={styles.sidebar}>
-        <EconomyPanel />
-        <StatsPanel />
-      </aside>
-    </main>
-  </div>
-);
+export const App = () => {
+  const { objectsDestroyed, hashBalance, unminted } = useGameStore((state) => ({
+    objectsDestroyed: state.objectsDestroyed,
+    hashBalance: state.balances.hash,
+    unminted: state.balances.unminted,
+  }));
+
+  const numberFormatter = useMemo(
+    () => new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }),
+    [],
+  );
+  const balanceFormatter = useMemo(
+    () => new Intl.NumberFormat('en-US', { maximumFractionDigits: 6 }),
+    [],
+  );
+
+  return (
+    <div className={styles.page}>
+      <TopBar />
+      <section className={styles.hero} id="top">
+        <div className={styles.heroCopy}>
+          <span className={styles.eyebrow}>Polygon-powered destruction economy</span>
+          <h1>Ignite the HashEquity arena</h1>
+          <p>
+            Drop into a living battlefield where every object you vaporize fuels the HASH
+            token ecosystem. Connect, compete, and mint your victories straight from the
+            arena floor.
+          </p>
+          <div className={styles.heroActions}>
+            <a className={styles.primaryAction} href="#play">
+              Launch the arena
+            </a>
+            <a className={styles.secondaryAction} href="#economy">
+              Explore the economy brief
+            </a>
+          </div>
+          <dl className={styles.heroStats}>
+            <div>
+              <dt>Objects destroyed</dt>
+              <dd>{numberFormatter.format(objectsDestroyed)}</dd>
+            </div>
+            <div>
+              <dt>Vault HASH balance</dt>
+              <dd>{balanceFormatter.format(hashBalance)}</dd>
+            </div>
+            <div>
+              <dt>Unminted HASH queued</dt>
+              <dd>{balanceFormatter.format(unminted)}</dd>
+            </div>
+          </dl>
+        </div>
+        <div className={styles.heroArt} aria-hidden="true">
+          <div className={styles.glow} />
+          <img src={heroCenter} className={styles.primaryCoin} alt="" />
+          <img src={heroOrbit} className={styles.secondaryCoin} alt="" />
+          <img src={heroSignal} className={styles.tertiaryCoin} alt="" />
+        </div>
+      </section>
+      <main className={styles.layout} id="play">
+        <div className={styles.primaryColumn}>
+          <GameBoard />
+          <LeaderboardPanel />
+          <MiniGamePanel />
+        </div>
+        <aside className={styles.sidebar} id="economy">
+          <EconomyPanel />
+          <div id="intel">
+            <StatsPanel />
+          </div>
+        </aside>
+      </main>
+    </div>
+  );
+};

--- a/frontend/src/components/EconomyPanel.module.css
+++ b/frontend/src/components/EconomyPanel.module.css
@@ -1,28 +1,31 @@
 .panel {
-  background: var(--surface-alt);
-  border-radius: 1rem;
-  padding: 1.5rem;
+  background: linear-gradient(150deg, rgba(15, 19, 34, 0.82), rgba(9, 12, 24, 0.78));
+  border-radius: 1.25rem;
+  padding: clamp(1.35rem, 3vw, 1.8rem);
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  border: 1px solid rgba(123, 92, 255, 0.2);
+  border: 1px solid rgba(255, 187, 90, 0.12);
+  box-shadow: 0 28px 60px rgba(3, 5, 16, 0.55);
+  backdrop-filter: blur(18px);
 }
 
 .panel header h2 {
   margin: 0 0 0.25rem;
-  font-size: 1.25rem;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
 }
 
 .panel header p {
   margin: 0;
-  font-size: 0.85rem;
-  color: rgba(245, 248, 255, 0.65);
+  font-size: 0.9rem;
+  color: rgba(240, 244, 255, 0.7);
 }
 
 .connection {
   margin-top: 0.25rem;
   font-size: 0.8rem;
-  color: rgba(245, 248, 255, 0.75);
+  color: rgba(255, 235, 214, 0.78);
 }
 
 .metrics {
@@ -51,13 +54,21 @@
 }
 
 .actions button {
-  background: var(--accent);
-  color: #fff;
+  background: linear-gradient(120deg, #ffd661, #ff8c42);
+  color: #1a1306;
   border: none;
-  padding: 0.65rem 1rem;
-  border-radius: 0.75rem;
+  padding: 0.7rem 1.15rem;
+  border-radius: 0.85rem;
   font-weight: 600;
   cursor: pointer;
+  box-shadow: 0 18px 36px rgba(255, 180, 80, 0.35);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.actions button:hover,
+.actions button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 38px rgba(255, 180, 80, 0.45);
 }
 
 .actions button:disabled {
@@ -106,12 +117,13 @@
 }
 
 .tradeForm button[type='submit'] {
-  background: rgba(123, 92, 255, 0.2);
+  background: rgba(255, 203, 118, 0.15);
   color: var(--accent);
+  border: 1px solid rgba(255, 211, 143, 0.35);
 }
 
 .refreshButton {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(245, 248, 255, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(18, 24, 40, 0.65);
+  color: rgba(245, 248, 255, 0.88);
+  border: 1px solid rgba(255, 211, 143, 0.2);
 }

--- a/frontend/src/components/LeaderboardPanel.module.css
+++ b/frontend/src/components/LeaderboardPanel.module.css
@@ -1,11 +1,13 @@
 .panel {
-  background: var(--surface-alt);
-  border-radius: 1rem;
-  padding: 1.5rem;
-  border: 1px solid rgba(123, 92, 255, 0.2);
+  background: linear-gradient(150deg, rgba(16, 18, 32, 0.88), rgba(13, 14, 26, 0.8));
+  border-radius: 1.25rem;
+  padding: clamp(1.4rem, 3vw, 1.9rem);
+  border: 1px solid rgba(255, 190, 102, 0.12);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
+  box-shadow: 0 30px 68px rgba(5, 6, 20, 0.55);
+  backdrop-filter: blur(16px);
 }
 
 .header {
@@ -17,20 +19,21 @@
 
 .header h2 {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
 }
 
 .header p {
   margin: 0.35rem 0 0;
-  font-size: 0.85rem;
-  color: rgba(245, 248, 255, 0.65);
+  font-size: 0.88rem;
+  color: rgba(237, 239, 255, 0.68);
 }
 
 .status {
   font-size: 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(245, 248, 255, 0.55);
+  letter-spacing: 0.16em;
+  color: rgba(244, 222, 190, 0.65);
   white-space: nowrap;
 }
 
@@ -42,9 +45,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: rgba(0, 0, 0, 0.25);
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
+  background: rgba(16, 13, 24, 0.75);
+  padding: 0.85rem 1.1rem;
+  border-radius: 0.95rem;
+  border: 1px solid rgba(255, 191, 110, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 180, 80, 0.12);
 }
 
 .personalMeta {
@@ -56,23 +61,25 @@
 .personalMeta p {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(245, 248, 255, 0.75);
+  color: rgba(255, 238, 210, 0.75);
 }
 
 .personalRank {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--accent);
-  background: rgba(123, 92, 255, 0.2);
+  letter-spacing: 0.16em;
+  color: rgba(34, 26, 16, 0.9);
+  background: linear-gradient(120deg, #ffd661, #ff8c42);
   border-radius: 999px;
-  padding: 0.15rem 0.6rem;
-  font-weight: 600;
+  padding: 0.18rem 0.7rem;
+  font-weight: 700;
+  box-shadow: 0 12px 26px rgba(255, 180, 80, 0.35);
 }
 
 .personal strong {
-  font-size: 1.4rem;
+  font-size: 1.45rem;
   font-variant-numeric: tabular-nums;
+  color: #fff4d8;
 }
 
 .error {
@@ -87,7 +94,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.75rem;
 }
 
 .row {
@@ -95,16 +102,17 @@
   grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: 1rem;
-  padding: 0.65rem 0.75rem;
-  border-radius: 0.75rem;
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.95rem;
+  background: rgba(18, 14, 28, 0.7);
+  border: 1px solid rgba(255, 195, 120, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(255, 195, 120, 0.08);
 }
 
 .rank {
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: rgba(245, 248, 255, 0.7);
+  color: rgba(245, 228, 200, 0.75);
 }
 
 .identity {
@@ -117,31 +125,32 @@
 .wallet {
   font-family: 'IBM Plex Mono', 'Fira Code', 'Source Code Pro', monospace;
   font-size: 0.85rem;
-  color: rgba(245, 248, 255, 0.85);
+  color: rgba(255, 245, 230, 0.85);
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .youBadge {
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  background: rgba(123, 92, 255, 0.35);
-  color: #fff;
+  letter-spacing: 0.18em;
+  background: rgba(255, 204, 130, 0.3);
+  color: rgba(255, 236, 210, 0.9);
   border-radius: 999px;
-  padding: 0.15rem 0.55rem;
+  padding: 0.2rem 0.55rem;
   font-weight: 600;
+  border: 1px solid rgba(255, 204, 130, 0.45);
 }
 
 .total {
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  color: rgba(245, 248, 255, 0.9);
+  color: rgba(255, 238, 210, 0.95);
 }
 
 .isYou {
-  border-color: rgba(123, 92, 255, 0.45);
-  box-shadow: 0 0 0 1px rgba(123, 92, 255, 0.35);
+  border-color: rgba(255, 198, 120, 0.45);
+  box-shadow: 0 0 0 1px rgba(255, 198, 120, 0.35);
 }
 
 .empty {
@@ -149,15 +158,16 @@
   text-align: center;
   font-size: 0.85rem;
   padding: 1.2rem;
-  border-radius: 0.75rem;
-  background: rgba(0, 0, 0, 0.2);
-  color: rgba(245, 248, 255, 0.7);
+  border-radius: 0.9rem;
+  background: rgba(20, 16, 32, 0.6);
+  color: rgba(245, 230, 208, 0.75);
+  border: 1px dashed rgba(255, 190, 110, 0.24);
 }
 
 .note {
   margin: 0;
   font-size: 0.8rem;
-  color: rgba(245, 248, 255, 0.65);
+  color: rgba(244, 229, 206, 0.65);
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/components/MiniGamePanel.module.css
+++ b/frontend/src/components/MiniGamePanel.module.css
@@ -1,36 +1,49 @@
 .panel {
-  background: var(--surface);
-  border-radius: 1rem;
-  padding: 1.5rem;
+  background: linear-gradient(150deg, rgba(17, 22, 38, 0.85), rgba(12, 14, 26, 0.78));
+  border-radius: 1.2rem;
+  padding: clamp(1.3rem, 3vw, 1.7rem);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  border: 1px solid rgba(123, 92, 255, 0.15);
+  gap: 0.85rem;
+  border: 1px solid rgba(255, 141, 213, 0.16);
+  box-shadow: 0 26px 58px rgba(7, 5, 18, 0.55);
+  backdrop-filter: blur(15px);
 }
 
 .panel h2 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.2rem;
+  letter-spacing: 0.02em;
 }
 
 .panel p {
   margin: 0;
-  color: rgba(245, 248, 255, 0.7);
+  color: rgba(243, 230, 255, 0.76);
 }
 
 .panel button {
   align-self: flex-start;
-  background: var(--accent);
-  color: #fff;
+  background: linear-gradient(120deg, #ff8cf7, #8f6bff);
+  color: #1a0c24;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 0.75rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 0.85rem;
   font-weight: 600;
   cursor: pointer;
+  box-shadow: 0 16px 34px rgba(182, 123, 255, 0.4);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.panel button:hover,
+.panel button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 36px rgba(182, 123, 255, 0.45);
 }
 
 .panel button:disabled {
-  background: rgba(255, 255, 255, 0.1);
-  color: rgba(245, 248, 255, 0.5);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(243, 230, 255, 0.55);
   cursor: default;
+  box-shadow: none;
+  transform: none;
 }

--- a/frontend/src/components/StatsPanel.module.css
+++ b/frontend/src/components/StatsPanel.module.css
@@ -1,11 +1,13 @@
 .panel {
-  background: var(--surface-alt);
-  border-radius: 1rem;
-  padding: 1.5rem;
-  border: 1px solid rgba(123, 92, 255, 0.2);
+  background: linear-gradient(150deg, rgba(13, 18, 32, 0.92), rgba(9, 13, 26, 0.75));
+  border-radius: 1.25rem;
+  padding: clamp(1.35rem, 3vw, 1.8rem);
+  border: 1px solid rgba(107, 178, 255, 0.18);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.05rem;
+  box-shadow: 0 28px 64px rgba(3, 6, 18, 0.48);
+  backdrop-filter: blur(16px);
 }
 
 .header {
@@ -22,18 +24,18 @@
 .header p {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(245, 248, 255, 0.65);
+  color: rgba(226, 235, 255, 0.7);
 }
 
 .status {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(245, 248, 255, 0.55);
+  letter-spacing: 0.18em;
+  color: rgba(205, 220, 255, 0.6);
 }
 
 .syncing {
-  color: var(--accent);
+  color: #77c6ff;
 }
 
 .error {
@@ -56,9 +58,10 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 0.75rem;
-  border-radius: 0.75rem;
-  background: rgba(0, 0, 0, 0.2);
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.9rem;
+  background: rgba(11, 16, 30, 0.75);
+  border: 1px solid rgba(107, 178, 255, 0.16);
 }
 
 .meta {
@@ -68,21 +71,23 @@
 }
 
 .meta img {
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   object-fit: cover;
-  border-radius: 0.6rem;
+  border-radius: 0.7rem;
+  box-shadow: 0 16px 26px rgba(22, 30, 45, 0.45);
 }
 
 .placeholder {
-  width: 40px;
-  height: 40px;
-  border-radius: 0.6rem;
+  width: 44px;
+  height: 44px;
+  border-radius: 0.7rem;
   display: grid;
   place-items: center;
-  background: rgba(123, 92, 255, 0.2);
-  color: var(--accent);
+  background: rgba(109, 180, 255, 0.2);
+  color: #77c6ff;
   font-size: 1.25rem;
+  border: 1px solid rgba(109, 180, 255, 0.3);
 }
 
 .meta div {
@@ -97,18 +102,20 @@
 
 .meta span {
   font-size: 0.75rem;
-  color: rgba(245, 248, 255, 0.55);
+  color: rgba(205, 220, 255, 0.65);
 }
 
 .count {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 1.1rem;
+  color: rgba(226, 239, 255, 0.95);
 }
 
 .empty {
   text-align: center;
   font-size: 0.85rem;
   padding: 1rem;
-  border-radius: 0.75rem;
-  background: rgba(0, 0, 0, 0.15);
+  border-radius: 0.85rem;
+  background: rgba(10, 15, 28, 0.7);
+  border: 1px dashed rgba(107, 178, 255, 0.26);
 }

--- a/frontend/src/components/TopBar.module.css
+++ b/frontend/src/components/TopBar.module.css
@@ -1,17 +1,99 @@
 .topBar {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 1rem;
-  padding: 1rem 0 2rem;
+  gap: clamp(1rem, 3vw, 2rem);
+  padding-bottom: clamp(1.75rem, 4vw, 2.5rem);
 }
 
-.topBar h1 {
-  margin: 0;
-  font-size: 1.75rem;
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: inherit;
 }
 
-.topBar p {
-  margin: 0.35rem 0 0;
-  color: rgba(245, 248, 255, 0.65);
+.logoWrap {
+  width: 50px;
+  height: 50px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 207, 112, 0.3), rgba(29, 22, 8, 0.6));
+  border: 1px solid rgba(255, 189, 73, 0.45);
+  box-shadow: 0 12px 24px rgba(255, 168, 66, 0.25);
+  overflow: hidden;
+}
+
+.logoWrap img {
+  width: 70%;
+  height: 70%;
+}
+
+.brand strong {
+  display: block;
+  font-size: 1.3rem;
+  letter-spacing: 0.01em;
+}
+
+.brand span {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(234, 232, 255, 0.65);
+}
+
+.links {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(1rem, 2.2vw, 1.75rem);
+  justify-self: center;
+}
+
+.links a {
+  position: relative;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(228, 234, 255, 0.7);
+  text-decoration: none;
+  transition: color 150ms ease;
+}
+
+.links a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.4rem;
+  height: 2px;
+  background: linear-gradient(120deg, rgba(255, 214, 97, 0.9), rgba(255, 140, 66, 0.6));
+  transform-origin: center;
+  transform: scaleX(0);
+  transition: transform 150ms ease;
+}
+
+.links a:hover,
+.links a:focus-visible {
+  color: #fff4d8;
+}
+
+.links a:hover::after,
+.links a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+@media (max-width: 820px) {
+  .topBar {
+    grid-template-columns: 1fr;
+    justify-items: stretch;
+    gap: 1.25rem;
+  }
+
+  .links {
+    justify-content: flex-start;
+  }
 }

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,12 +1,23 @@
 import { ConnectButton } from '@rainbow-me/rainbowkit';
+import logo from '../assets/coins/hash-core.svg';
 import styles from './TopBar.module.css';
 
 export const TopBar = () => (
   <header className={styles.topBar}>
-    <div>
-      <h1>HashEquity Operations Console</h1>
-      <p>Track vault health, run mints, and trigger bonuses in the core loop.</p>
-    </div>
-    <ConnectButton />
+    <a className={styles.brand} href="#top">
+      <span className={styles.logoWrap}>
+        <img src={logo} alt="HashEquity" />
+      </span>
+      <div>
+        <strong>HashEquity</strong>
+        <span>Web3 destruction economy</span>
+      </div>
+    </a>
+    <nav className={styles.links} aria-label="Primary">
+      <a href="#play">Play</a>
+      <a href="#economy">Economy</a>
+      <a href="#intel">Intel feed</a>
+    </nav>
+    <ConnectButton chainStatus="icon" showBalance={false} />
   </header>
 );

--- a/frontend/src/state/gameStore.ts
+++ b/frontend/src/state/gameStore.ts
@@ -50,6 +50,15 @@ const randomPosition = (size: SpawnDefinition['size']): ObjectPosition => {
 const randomFloatDuration = () => Number((6 + Math.random() * 4).toFixed(2));
 const randomFloatDelay = () => Number((Math.random() * 6).toFixed(2));
 
+const parseBalance = (value: number | string): number => {
+  const numeric = typeof value === 'string' ? Number(value) : value;
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+
+  return Number(numeric.toFixed(10));
+};
+
 const createObject = (): ActiveObject => {
   const definition = pickSpawnDefinition();
   const id = `object-${nextObjectId++}`;
@@ -233,14 +242,6 @@ export const useGameStore = create<GameState>()(
       }, false, 'tradeInForHash');
     },
     syncBackendBalances: ({ hashBalance, unmintedHash, objectsDestroyed }) => {
-      const parse = (value: number | string) => {
-        const numeric = typeof value === 'string' ? Number(value) : value;
-        if (!Number.isFinite(numeric)) {
-          return 0;
-        }
-        return Number(numeric.toFixed(10));
-      };
-
       const parseDestroyed = (value?: number | string) => {
         if (value === undefined || value === null) {
           return undefined;
@@ -264,7 +265,7 @@ export const useGameStore = create<GameState>()(
           unminted: parseBalance(unmintedHash),
         },
         objectsDestroyed:
-          objectsDestroyed !== undefined ? parse(objectsDestroyed) : state.objectsDestroyed,
+          destroyed !== undefined ? destroyed : state.objectsDestroyed,
       }), false, 'syncBackendBalances');
     },
     addEvent: (message) => {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,14 +1,15 @@
 :root {
   color-scheme: dark;
-  --background: #05070c;
-  --surface: #101626;
-  --surface-alt: #1b2336;
-  --text: #f5f8ff;
-  --accent: #7b5cff;
-  --accent-soft: rgba(123, 92, 255, 0.16);
+  --background: #04030a;
+  --surface: #101525;
+  --surface-alt: rgba(17, 22, 39, 0.76);
+  --text: #f6f8ff;
+  --accent: #ffb347;
+  --accent-soft: rgba(255, 179, 71, 0.24);
   --success: #2dd4bf;
   --danger: #ef4444;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: 'Inter', 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.55;
 }
 
 * {
@@ -18,10 +19,13 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at 20% 20%, rgba(123, 92, 255, 0.12), transparent 55%),
-    radial-gradient(circle at 80% 20%, rgba(45, 212, 191, 0.12), transparent 55%),
+  background:
+    radial-gradient(circle at 15% 20%, rgba(255, 182, 92, 0.18), transparent 55%),
+    radial-gradient(circle at 85% 18%, rgba(104, 172, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 50% 82%, rgba(255, 99, 180, 0.12), transparent 60%),
     var(--background);
   color: var(--text);
+  background-attachment: fixed;
 }
 
 a {


### PR DESCRIPTION
## Summary
- redesign the landing hero and layout with branded background art and live balance callouts
- refresh the top navigation with logo treatment and section anchors for play, economy, and intel panels
- update economy, stats, leaderboard, and mini-game cards with glassy gradients and accentuated CTAs to match the new theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0be1c82f4832e9e3e1327a201a648