### PR TITLE
Fix spawn definitions syntax and align types

### DIFF
--- a/frontend/src/state/gameStore.ts
+++ b/frontend/src/state/gameStore.ts
@@ -251,7 +251,7 @@ export const useGameStore = create<GameState>()(
         };
       }, false, 'tradeInForHash');
     },
-    syncBackendBalances: ({ hashBalance, unmintedHash, objectsDestroyed }) => {
+    syncBackendBalances: ({ hashBalance, unmintedHash, objectsDestroyed, vaultHashBalance }) => {
       const parseDestroyed = (value?: number | string) => {
         if (value === undefined || value === null) {
           return undefined;

--- a/frontend/src/state/gameTypes.ts
+++ b/frontend/src/state/gameTypes.ts
@@ -19,7 +19,9 @@ export type GameObjectType =
   | 'object0-7'
   | 'object0-8'
   | 'object0-9'
-  | 'object1-0';
+  | 'object1-0'
+  | 'object1-1'
+  | 'object1-2';
 
 export type GameObjectSize = 'small' | 'medium' | 'large';
 

--- a/frontend/src/state/spawnDefinitions.ts
+++ b/frontend/src/state/spawnDefinitions.ts
@@ -121,7 +121,8 @@ export const spawnDefinitions: SpawnDefinition[] = [
     spawnChance: 0.00005,
     reward: { type: 'unminted_hash', value: 0.0001 },
     health: 1,
-    {
+  },
+  {
     type: 'object1-2',
     name: 'Object 1-2',
     image: object12,
@@ -129,4 +130,5 @@ export const spawnDefinitions: SpawnDefinition[] = [
     spawnChance: 0.1,
     reward: { type: 'unminted_hash', value: 0.000000025 },
     health: 1,
+  },
 ];


### PR DESCRIPTION
## Summary
- correct the malformed spawn definition entry and preserve the spawn chance distribution
- extend the spawn type union for the new objects
- update the backend sync handler to read the vault balance payload safely

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e128c07830832e845cbe00809d27d0