### PR TITLE
Add inventory item rewards and frontend inventory panel

### DIFF
--- a/backend/controllers/gameController.js
+++ b/backend/controllers/gameController.js
@@ -11,6 +11,84 @@ const humanizeObjectId = (objectId = "") =>
     .trim()
     .replace(/(^|\s)\S/g, (letter) => letter.toUpperCase());
 
+const serializeInventory = (inventory = []) => {
+  if (!Array.isArray(inventory)) {
+    return [];
+  }
+
+  return inventory
+    .map((item) => {
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+
+      const quantity = Math.max(0, Math.floor(toNumber(item.quantity)));
+      if (!item.itemId || quantity <= 0) {
+        return null;
+      }
+
+      const description = typeof item.description === "string" ? item.description : "";
+      const lastUpdatedAt = item.lastUpdatedAt instanceof Date
+        ? item.lastUpdatedAt.toISOString()
+        : item.lastUpdatedAt || new Date().toISOString();
+
+      return {
+        itemId: item.itemId,
+        name: item.name || item.itemId,
+        image: item.image || "",
+        quantity,
+        description,
+        lastUpdatedAt,
+      };
+    })
+    .filter(Boolean);
+};
+
+const normalizeDestroyReward = (reward) => {
+  if (reward === undefined || reward === null) {
+    return { type: "none" };
+  }
+
+  if (typeof reward === "number" || typeof reward === "string") {
+    const value = toNumber(reward);
+    return { type: "unminted_hash", value };
+  }
+
+  if (typeof reward === "object") {
+    const { type } = reward;
+    if (type === "unminted_hash") {
+      return { type, value: toNumber(reward.value) };
+    }
+
+    if (type === "item") {
+      const itemId = typeof reward.itemId === "string" ? reward.itemId.trim() : "";
+      if (!itemId) {
+        return { type: "none" };
+      }
+
+      const name =
+        typeof reward.name === "string" && reward.name.trim()
+          ? reward.name.trim()
+          : itemId;
+      const image = typeof reward.image === "string" ? reward.image : "";
+      const description =
+        typeof reward.description === "string" && reward.description.trim()
+          ? reward.description.trim()
+          : "";
+
+      return {
+        type: "item",
+        itemId,
+        name,
+        image,
+        description,
+      };
+    }
+  }
+
+  return { type: "none" };
+};
+
 exports.getStats = async (_req, res) => {
   try {
     const stats = await Stats.find().sort({ destroyed: -1, objectId: 1 });
@@ -45,7 +123,8 @@ exports.getBalances = async (req, res) => {
     res.json({
       hashBalance: toNumber(user?.hashBalance),
       unmintedHash: toNumber(user?.unmintedHash),
-      objectsDestroyed: toNumber(user?.objectsDestroyed)
+      objectsDestroyed: toNumber(user?.objectsDestroyed),
+      inventory: serializeInventory(user?.inventory)
     });
   } catch (err) {
     console.error("Balance fetch error:", err);
@@ -55,7 +134,7 @@ exports.getBalances = async (req, res) => {
 
 exports.destroyObject = async (req, res) => {
   try {
-    const { wallet, objectId, reward = 0, objectName, objectImage } = req.body;
+    const { wallet, objectId, reward: rewardPayload = 0, objectName, objectImage } = req.body;
 
     if (!wallet || !objectId) {
       return res.status(400).json({ error: "Missing wallet or objectId" });
@@ -67,15 +146,15 @@ exports.destroyObject = async (req, res) => {
       return res.status(400).json({ error: "Missing wallet" });
     }
 
-    const numericReward = toNumber(reward);
+    const rewardDetails = normalizeDestroyReward(rewardPayload);
 
     const userUpdate = {
       $setOnInsert: { walletAddress: normalizedWallet },
       $inc: { objectsDestroyed: 1 }
     };
 
-    if (numericReward !== 0) {
-      userUpdate.$inc.unmintedHash = numericReward;
+    if (rewardDetails.type === "unminted_hash" && rewardDetails.value !== 0) {
+      userUpdate.$inc.unmintedHash = rewardDetails.value;
     }
 
     const user = await User.findOneAndUpdate(
@@ -83,6 +162,36 @@ exports.destroyObject = async (req, res) => {
       userUpdate,
       { new: true, upsert: true, setDefaultsOnInsert: true }
     );
+
+    if (rewardDetails.type === "item" && user) {
+      const now = new Date();
+      const existing = user.inventory.find((entry) => entry.itemId === rewardDetails.itemId);
+
+      if (existing) {
+        const currentQuantity = Math.max(0, Math.floor(toNumber(existing.quantity)));
+        existing.quantity = currentQuantity + 1;
+        existing.lastUpdatedAt = now;
+        existing.name = rewardDetails.name;
+        if (rewardDetails.image) {
+          existing.image = rewardDetails.image;
+        }
+        if (rewardDetails.description) {
+          existing.description = rewardDetails.description;
+        }
+      } else {
+        user.inventory.push({
+          itemId: rewardDetails.itemId,
+          name: rewardDetails.name,
+          image: rewardDetails.image,
+          quantity: 1,
+          description: rewardDetails.description,
+          lastUpdatedAt: now,
+        });
+      }
+
+      user.markModified("inventory");
+      await user.save();
+    }
 
     const statUpdates = {};
     if (objectName) statUpdates.name = objectName;
@@ -105,7 +214,8 @@ exports.destroyObject = async (req, res) => {
     res.json({
       hashBalance: toNumber(user?.hashBalance),
       unmintedHash: toNumber(user?.unmintedHash),
-      objectsDestroyed: toNumber(user?.objectsDestroyed)
+      objectsDestroyed: toNumber(user?.objectsDestroyed),
+      inventory: serializeInventory(user?.inventory)
     });
   } catch (err) {
     console.error("Destroy error:", err);
@@ -151,10 +261,10 @@ exports.tradeInForHash = async (req, res) => {
     res.json({
       hashBalance: updatedHashBalance,
       unmintedHash: updatedUnminted,
-      objectsDestroyed: toNumber(user?.objectsDestroyed),
       tradedAmount: tradeAmount,
       mintedAmount,
-      objectsDestroyed: toNumber(user?.objectsDestroyed)
+      objectsDestroyed: toNumber(user?.objectsDestroyed),
+      inventory: serializeInventory(user?.inventory)
     });
   } catch (err) {
     console.error("Trade-in error:", err);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,5 +1,17 @@
 const mongoose = require("mongoose");
 
+const inventoryItemSchema = new mongoose.Schema(
+  {
+    itemId: { type: String, required: true, trim: true },
+    name: { type: String, required: true, trim: true },
+    image: { type: String, default: '' },
+    quantity: { type: Number, default: 1, min: 0 },
+    description: { type: String, default: '' },
+    lastUpdatedAt: { type: Date, default: Date.now },
+  },
+  { _id: false }
+);
+
 const userSchema = new mongoose.Schema(
   {
     walletAddress: {
@@ -12,6 +24,7 @@ const userSchema = new mongoose.Schema(
     unmintedHash: { type: Number, default: 0 },
     hashBalance: { type: Number, default: 0 },
     objectsDestroyed: { type: Number, default: 0 },
+    inventory: { type: [inventoryItemSchema], default: [] },
     isAdmin: { type: Boolean, default: false }
   },
   { timestamps: true }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { MiniGamePanel } from './components/MiniGamePanel';
 import { TopBar } from './components/TopBar';
 import { StatsPanel } from './components/StatsPanel';
 import { LeaderboardPanel } from './components/LeaderboardPanel';
+import { InventoryPanel } from './components/InventoryPanel';
 import { useGameStore } from './state/gameStore';
 import heroCenter from './assets/coins/Object1-0.png';
 import heroOrbit from './assets/coins/Object0-6.png';
@@ -77,6 +78,7 @@ export const App = () => {
         </div>
         <aside className={styles.sidebar} id="economy">
           <EconomyPanel />
+          <InventoryPanel />
           <div id="intel">
             <StatsPanel />
           </div>

--- a/frontend/src/components/EconomyPanel.tsx
+++ b/frontend/src/components/EconomyPanel.tsx
@@ -38,6 +38,7 @@ export const EconomyPanel = () => {
         unmintedHash: result.unmintedHash,
         vaultHashBalance: result.vaultHashBalance,
         objectsDestroyed: result.objectsDestroyed,
+        inventory: result.inventory,
       });
       tradeInForHash({ tradedAmount: result.tradedAmount, mintedAmount: result.mintedAmount });
       setTradeAmount('0.00000000');
@@ -54,6 +55,7 @@ export const EconomyPanel = () => {
         unmintedHash: data.unmintedHash,
         vaultHashBalance: data.vaultHashBalance,
         objectsDestroyed: data.objectsDestroyed,
+        inventory: data.inventory,
       });
     }
   }, [data, syncBackendBalances]);

--- a/frontend/src/components/GameObjectCard.tsx
+++ b/frontend/src/components/GameObjectCard.tsx
@@ -23,6 +23,7 @@ export const GameObjectCard = ({ object }: Props) => {
         hashBalance: balances.hashBalance,
         unmintedHash: balances.unmintedHash,
         objectsDestroyed: balances.objectsDestroyed,
+        inventory: balances.inventory,
       });
       const totalDestroys = Number(balances.objectsDestroyed);
       const formattedTotal = Number.isFinite(totalDestroys)
@@ -54,17 +55,36 @@ export const GameObjectCard = ({ object }: Props) => {
       mutate({
         wallet: address,
         objectId: object.type,
-        reward: object.reward.type === 'unminted_hash' ? object.reward.value : undefined,
+        reward:
+          object.reward.type === 'unminted_hash'
+            ? { type: 'unminted_hash', value: object.reward.value }
+            : object.reward.type === 'item'
+            ? {
+                type: 'item',
+                itemId: object.reward.itemId,
+                name: object.reward.name,
+                image: object.reward.image,
+                description: object.reward.description,
+              }
+            : undefined,
         objectName: object.name,
         objectImage: object.image,
       });
     }
   };
 
-  const actionLabel =
-    object.reward.type === 'unminted_hash'
-      ? `Collect ${object.reward.value.toFixed(10)} unminted HASH from ${object.name}`
-      : `Trigger ${object.reward.label} from ${object.name}`;
+  const actionLabel = (() => {
+    switch (object.reward.type) {
+      case 'unminted_hash':
+        return `Collect ${object.reward.value.toFixed(10)} unminted HASH from ${object.name}`;
+      case 'mini_game':
+        return `Trigger ${object.reward.label} from ${object.name}`;
+      case 'item':
+        return `Collect ${object.reward.name} from ${object.name}`;
+      default:
+        return `Destroy ${object.name}`;
+    }
+  })();
 
   return (
     <button

--- a/frontend/src/components/InventoryPanel.module.css
+++ b/frontend/src/components/InventoryPanel.module.css
@@ -1,0 +1,121 @@
+.panel {
+  background: rgba(8, 12, 24, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: 0 20px 40px rgba(7, 10, 18, 0.35);
+  backdrop-filter: blur(14px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.header p {
+  margin: 0.45rem 0 0;
+  color: rgba(222, 230, 255, 0.68);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.empty {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  background: rgba(20, 26, 44, 0.75);
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  color: rgba(216, 224, 255, 0.7);
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.entry {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.85rem;
+  align-items: start;
+  padding: 0.8rem 0.9rem;
+  border-radius: 16px;
+  background: rgba(15, 22, 38, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.art,
+.placeholder {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  object-fit: contain;
+  background: rgba(12, 18, 32, 0.9);
+  box-shadow: 0 12px 24px rgba(6, 9, 16, 0.45);
+}
+
+.placeholder {
+  display: grid;
+  place-items: center;
+  color: rgba(255, 255, 255, 0.2);
+  font-size: 0.75rem;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #fff4d8;
+}
+
+.quantity {
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 214, 120, 0.9);
+  font-weight: 600;
+}
+
+.description {
+  margin: 0;
+  color: rgba(214, 222, 255, 0.72);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.timestamp {
+  font-size: 0.8rem;
+  color: rgba(173, 188, 255, 0.55);
+}
+
+@media (max-width: 520px) {
+  .entry {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .art,
+  .placeholder {
+    width: 48px;
+    height: 48px;
+  }
+}

--- a/frontend/src/components/InventoryPanel.tsx
+++ b/frontend/src/components/InventoryPanel.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import { useGameStore } from '../state/gameStore';
+import styles from './InventoryPanel.module.css';
+
+export const InventoryPanel = () => {
+  const inventory = useGameStore((state) => state.inventory);
+
+  const items = useMemo(
+    () => [...inventory].sort((a, b) => b.lastUpdated - a.lastUpdated),
+    [inventory],
+  );
+
+  const timestampFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      }),
+    [],
+  );
+
+  return (
+    <section className={styles.panel} aria-labelledby="inventory-heading">
+      <header className={styles.header}>
+        <h2 id="inventory-heading">Inventory</h2>
+        <p>Collectible rewards persist with your account and unlock future utility.</p>
+      </header>
+      {items.length === 0 ? (
+        <p className={styles.empty}>Destroy rare objects to uncover collectible items.</p>
+      ) : (
+        <ul className={styles.list}>
+          {items.map((item) => {
+            const acquiredDate = new Date(item.lastUpdated);
+            const formatted = timestampFormatter.format(acquiredDate);
+            return (
+              <li key={item.itemId} className={styles.entry}>
+                {item.image ? (
+                  <img src={item.image} alt="" className={styles.art} aria-hidden="true" />
+                ) : (
+                  <div className={styles.placeholder} aria-hidden="true" />
+                )}
+                <div className={styles.details}>
+                  <div className={styles.row}>
+                    <span className={styles.name}>{item.name}</span>
+                    <span className={styles.quantity}>×{item.quantity}</span>
+                  </div>
+                  {item.description ? (
+                    <p className={styles.description}>{item.description}</p>
+                  ) : null}
+                  <time className={styles.timestamp} dateTime={acquiredDate.toISOString()}>
+                    Last acquired {formatted}
+                  </time>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -12,17 +12,40 @@ type LeaderboardEntry = {
   objectsDestroyed: number;
 };
 
+type InventoryEntry = {
+  itemId: string;
+  name: string;
+  image: string;
+  quantity: number | string;
+  lastUpdatedAt?: number | string | Date;
+  description?: string | null;
+};
+
 type BalancesResponse = {
   hashBalance: number | string;
   unmintedHash: number | string;
   vaultHashBalance?: number | string | null;
   objectsDestroyed: number | string;
+  inventory?: InventoryEntry[] | null;
 };
+
+type DestroyRewardPayload =
+  | {
+      type: 'unminted_hash';
+      value: number;
+    }
+  | {
+      type: 'item';
+      itemId: string;
+      name: string;
+      image: string;
+      description?: string | null;
+    };
 
 type DestroyPayload = {
   wallet: string;
   objectId: string;
-  reward?: number;
+  reward?: DestroyRewardPayload;
   objectName?: string;
   objectImage?: string;
 };
@@ -150,6 +173,8 @@ export type {
   StatsEntry,
   LeaderboardEntry,
   BalancesResponse,
+  InventoryEntry,
+  DestroyRewardPayload,
   DestroyPayload,
   TradePayload,
   TradeResponse,

--- a/frontend/src/state/gameTypes.ts
+++ b/frontend/src/state/gameTypes.ts
@@ -6,6 +6,13 @@ export type RewardDefinition =
   | {
       type: 'mini_game';
       label: string;
+    }
+  | {
+      type: 'item';
+      itemId: string;
+      name: string;
+      image: string;
+      description?: string;
     };
 
 export type GameObjectType =
@@ -19,7 +26,9 @@ export type GameObjectType =
   | 'object0-7'
   | 'object0-8'
   | 'object0-9'
-  | 'object1-0';
+  | 'object1-0'
+  | 'object1-1'
+  | 'object1-2';
 
 export type GameObjectSize = 'small' | 'medium' | 'large';
 

--- a/frontend/src/state/spawnDefinitions.ts
+++ b/frontend/src/state/spawnDefinitions.ts
@@ -115,13 +115,20 @@ export const spawnDefinitions: SpawnDefinition[] = [
   },
   {
     type: 'object1-1',
-    name: 'Object 1-1',
+    name: 'Hash Relic Prototype',
     image: object11,
     size: 'small',
     spawnChance: 0.00005,
-    reward: { type: 'unminted_hash', value: 0.0001 },
+    reward: {
+      type: 'item',
+      itemId: 'object1-1',
+      name: 'Hash Relic Prototype',
+      image: object11,
+      description: 'First collectible minted from destroy rewards.',
+    },
     health: 1,
-    {
+  },
+  {
     type: 'object1-2',
     name: 'Object 1-2',
     image: object12,
@@ -129,4 +136,5 @@ export const spawnDefinitions: SpawnDefinition[] = [
     spawnChance: 0.1,
     reward: { type: 'unminted_hash', value: 0.000000025 },
     health: 1,
+  },
 ];


### PR DESCRIPTION
## Summary
- enable backend destroy and balance endpoints to normalize destroy rewards and persist inventory items
- extend the frontend store, types, and API calls to sync item rewards and spawn the Hash Relic Prototype collectible
- add an inventory panel UI that showcases collected items alongside the existing economy panels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e128c07830832e845cbe00809d27d0