### PR TITLE
Define leaderboard limit constant for game controller

### DIFF
--- a/backend/controllers/gameController.js
+++ b/backend/controllers/gameController.js
@@ -3,6 +3,8 @@ const User = require("../models/User");
 const { normalizeWallet } = require("../config/admin");
 const { toNumber, toFixedAmount } = require("../utils/number");
 
+const LEADERBOARD_LIMIT = 100;
+
 const humanizeObjectId = (objectId = "") =>
   objectId
     .replace(/[-_]+/g, " ")


### PR DESCRIPTION
## Summary
- define a LEADERBOARD_LIMIT constant in the game controller to align with the frontend expectation
- prevent the leaderboard endpoint from throwing a ReferenceError when limiting results

## Testing
- node - <<'NODE'
const controller = require('./backend/controllers/gameController');
const User = require('./backend/models/User');

User.find = () => ({
  select() { return this; },
  sort() { return this; },
  limit() { return this; },
  lean: async () => [{ walletAddress: '0x123', objectsDestroyed: 42 }],
});

const res = {
  json(data) {
    console.log('response', data);
  },
  status(code) {
    this.statusCode = code;
    return this;
  },
};

controller.getLeaderboard({}, res)
  .then(() => console.log('leaderboard handler completed'))
  .catch((err) => console.error('error', err));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e1b9a96d30832eb42badca98c4aa49