### PR TITLE
Fix spawn asset references and spawn definition typo

### DIFF
--- a/backend/controllers/gameController.js
+++ b/backend/controllers/gameController.js
@@ -3,6 +3,8 @@ const User = require("../models/User");
 const { normalizeWallet } = require("../config/admin");
 const { toNumber, toFixedAmount } = require("../utils/number");
 
+const LEADERBOARD_LIMIT = 100;
+
 const humanizeObjectId = (objectId = "") =>
   objectId
     .replace(/[-_]+/g, " ")

--- a/frontend/src/assets/coins/vault-emblem.svg
+++ b/frontend/src/assets/coins/vault-emblem.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="vaultGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6b73ff" />
+      <stop offset="100%" stop-color="#000dff" />
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#vaultGradient)" stroke="#1a1f4b" stroke-width="4" />
+  <path
+    d="M32 16a16 16 0 1 0 16 16A16 16 0 0 0 32 16zm0 26a10 10 0 1 1 10-10 10 10 0 0 1-10 10z"
+    fill="#f7f9ff"
+  />
+  <path d="M32 22a10 10 0 0 0-10 10h6a4 4 0 0 1 4-4z" fill="#ffd166" />
+  <circle cx="32" cy="32" r="4" fill="#ffd166" stroke="#1a1f4b" stroke-width="2" />
+</svg>

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { ConnectButton } from '@rainbow-me/rainbowkit';
-import logo from '../assets/coins/hash-core.svg';
+import logo from '../assets/branding/Logo.png';
 import styles from './TopBar.module.css';
 
 export const TopBar = () => (

--- a/frontend/src/state/spawnDefinitions.ts
+++ b/frontend/src/state/spawnDefinitions.ts
@@ -124,7 +124,7 @@ export const spawnDefinitions: SpawnDefinition[] = [
       itemId: 'object1-1',
       name: 'Hash Relic Prototype',
       image: object11,
-      description: 'A rare coin treasured for it's beautiful background!',
+      description: 'A rare coin treasured for its beautiful background!',
     },
     health: 1,
   },


### PR DESCRIPTION
## Summary
- correct the spawn definition description string so TypeScript no longer breaks the build
- point the top bar logo at an existing branding asset
- add a vault emblem SVG so the economy panel can render without missing assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b9a96d30832eb42badca98c4aa49